### PR TITLE
✨ [feat] Coordinator, NavigationStack을 이용하여 뷰 네비게이팅 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/App/Coordinator.swift
+++ b/FunForYou/FunForYou/Sources/App/Coordinator.swift
@@ -1,0 +1,31 @@
+//
+//  Coordinator.swift
+//  FunForYou
+//
+//  Created by 한건희 on 5/30/25.
+//
+
+import SwiftUI
+import Combine
+import Foundation
+
+final class Coordinator: ObservableObject {
+    @Published var path: [Path] = []
+    
+    func push(_ path: Path) {
+        self.path.append(path)
+    }
+    
+    func popLast() {
+        _ = self.path.popLast()
+    }
+    
+    func removeAll() {
+        self.path.removeAll()
+    }
+}
+
+enum Path {
+    case main
+    case aView
+}

--- a/FunForYou/FunForYou/Sources/App/FunForYouApp.swift
+++ b/FunForYou/FunForYou/Sources/App/FunForYouApp.swift
@@ -1,0 +1,41 @@
+//
+//  FunForYouApp.swift
+//  FunForYou
+//
+//  Created by 한건희 on 5/30/25.
+//
+
+import SwiftUI
+
+@main
+struct FunForYouApp: App {
+    @StateObject var coordinator = Coordinator()
+    @State var isSplashing: Bool = true
+    
+    var body: some Scene {
+        WindowGroup {
+            ZStack {
+                NavigationStack(path: $coordinator.path) {
+                    VStack {
+                        
+                    }
+                    .navigationDestination(for: Path.self) { path in
+                        switch path {
+                        case .main:
+                            TestMainView(coordinator: coordinator)
+                                .toolbar(.hidden, for: .navigationBar)
+                        case .aView:
+                            Text("aView")
+                                .toolbar(.hidden, for: .navigationBar)
+                        }
+                    }
+                }
+                .onAppear {
+                    coordinator.push(.main)
+                }
+            }
+            
+        }
+        .modelContainer(for: [Poem.self, Daily.self, Appreciation.self])
+    }
+}


### PR DESCRIPTION

### Issue Number

close #3

### 🖥️ 작업 내역

Coordinator 클래스를 만들어, 앱 전체에서 공유되는 Navigation 상태를 관리하도록 구현했습니다.
NavigationStack과 navigationDestination(for:)을 활용하여 각 Path에 해당하는 뷰로 네비게이션할 수 있도록 구성했습니다.
앱 실행 시 main 화면으로 이동되도록 기본 진입점을 설정했습니다.

```Swift
final class Coordinator: ObservableObject {
    @Published var path: [Path] = []

    func push(_ path: Path) {
        self.path.append(path)
    }

    func popLast() {
        _ = self.path.popLast()
    }

    func removeAll() {
        self.path.removeAll()
    }
}
```

Coordinator는 ObservableObject로 선언되어 있고, @Published된 path 배열을 통해 SwiftUI의 NavigationStack과 연동됩니다.
push, popLast, removeAll 메서드를 통해 네비게이션 상태를 외부에서 제어할 수 있습니다.

```Swift
NavigationStack(path: $coordinator.path) {
    ...
    .navigationDestination(for: Path.self) { path in
        switch path {
        case .main:
            TestMainView(coordinator: coordinator)
        case .aView:
            Text("aView")
        }
    }
}
```

NavigationStack은 @Published var path를 바인딩하여 화면 전환을 관리합니다.
navigationDestination(for:)는 Enum인 Path의 각 case에 따라 이동할 뷰를 지정합니다.
앱 최초 실행 시 .onAppear를 통해 coordinator.push(.main)을 호출하여 기본 화면으로 진입합니다.

### ✅ 참고 사항
향후 다른 화면이 추가될 경우, Path enum에 새로운 case를 추가하고 navigationDestination에 해당 case에 대한 뷰를 매핑하면 됩니다.
Coordinator를 싱글톤으로 만들지 않고 @StateObject로 주입한 이유는 SwiftUI의 상태 관리 흐름을 따르기 위함입니다.