### PR TITLE
✨ [feat] 일상 읽기 뷰 UI 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
@@ -7,8 +7,10 @@
 
 import SwiftUI
 
+/// 일상 읽기 뷰
 struct DailyReadingView: View {
     @StateObject var viewModel: DailyReadingViewModel
+    @Environment(\.dismiss) private var dismiss
     
     init(daily: Daily, coordinator: Coordinator) {
         _viewModel = StateObject(wrappedValue: DailyReadingViewModel(daily: daily, coordinator: coordinator))
@@ -16,7 +18,28 @@ struct DailyReadingView: View {
     
     var body: some View {
         VStack {
+            DailyReadingNavigationBar()
             
+            ScrollView {
+                DailyReadingContentView(
+                    title: viewModel.state.daily.title,
+                    content: viewModel.state.daily.content,
+                    imagePath: viewModel.state.daily.image
+                )
+                
+                InspiredPoemCardsView(
+                    inspirationID: viewModel.state.daily.id,
+                    poems: viewModel.state.inspiredPoems
+                )
+                .padding(.top, 64)
+                .padding(.horizontal, 24)
+            }
         }
     }
+}
+
+#Preview {
+    @Previewable @StateObject var coordinator = Coordinator()
+    
+    DailyReadingView(daily: Daily.mockData, coordinator: coordinator)
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
@@ -11,6 +11,7 @@ final class DailyReadingViewModel: ViewModelable {
     @ObservedObject var coordinator: Coordinator
     struct State {
         var daily: Daily
+        var inspiredPoems: [Poem] = []
     }
     
     enum Action {

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ContentSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ContentSceneView.swift
@@ -1,0 +1,30 @@
+//
+//  ContentSceneView.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/4/25.
+//
+import SwiftUI
+
+/// 일상 시상 내용 서브뷰
+struct ContentSceneView: View {
+    /// 일상 시상 내용 텍스트
+    var content: String?
+    
+    var body: some View {
+        VStack {
+            if let content {
+                Text(content.forceCharWrapping)
+                    .font(FFYFont.body)
+                    .lineSpacing(5)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentSceneView(
+        content: "오늘 첫 봄비가 내렸다. 골목을 같이 25개 설비다 넘으라 좀처럼 그때가 오전이 플레이를"
+    )
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingContentView.swift
@@ -1,0 +1,37 @@
+//
+//  DailyReadingContentView.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/4/25.
+//
+import SwiftUI
+
+/// 일상 읽기 서브뷰 (관련 시 목록 제외)
+struct DailyReadingContentView: View {
+    /// 시상 제목
+    var title: String?
+    /// 시상 내용
+    var content: String?
+    /// 시상 이미지 경로
+    var imagePath: String?
+    
+    var body: some View {
+        VStack (alignment: .leading) {
+            TitleSceneView(title: self.title)
+            
+            ImageSceneView(imagePath: self.imagePath)
+            
+            ContentSceneView(content: self.content)
+            
+        }
+        .padding(.horizontal, 24)
+    }
+}
+
+#Preview {
+    DailyReadingContentView(
+        title: Daily.mockData.title,
+        content: Daily.mockData.content,
+        imagePath: "/path" // 예시 path 입니다.
+    )
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
@@ -1,0 +1,45 @@
+//
+//  DailyReadingNavigationBar.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/4/25.
+//
+import SwiftUI
+
+struct DailyReadingNavigationBar: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            NavigationBar(
+                title: "일상 읽기",
+                style: .backTitle,
+                onBack: {
+                    dismiss()
+                }
+            )
+            
+            Menu {
+                Button {
+                    // TODO: 감상 편집 페이지로 이동(berry)
+                } label: {
+                    Text("고쳐 쓰기")
+                }
+                
+                Button(role: .destructive) {
+                    // TODO: 정말 지우겠냐는 alert 띄우고 액션 연결하기(berry)
+                } label: {
+                    Text("지우기")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.title3)
+                    .foregroundStyle(FFYColor.pinkDark)
+                    .padding(.bottom)
+                    .padding(.trailing, 24)
+            }
+
+        }
+
+    }
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ImageSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ImageSceneView.swift
@@ -1,0 +1,39 @@
+//
+//  ImageSceneView.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/4/25.
+//
+import SwiftUI
+
+/// 일상 시상 이미지 서브뷰
+struct ImageSceneView: View {
+    /// 시상 이미지 경로
+    var imagePath: String?
+    var isPadding: Bool {
+        imagePath != nil
+    }
+    
+    var body: some View {
+        VStack {
+            if let imagePath {
+                // TODO: - ImageManager이용해서 loadImage 구현 (Berry)
+                Image("PoemPaperSet")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 240)
+                    .clipped()
+                    .cornerRadius(20)
+                    .padding(.horizontal, 24)
+                    .allowsHitTesting(false)
+            }
+        }
+        .padding(.bottom, isPadding ? 20 : 0)
+    }
+}
+
+#Preview {
+    // 예시 path 입니다.
+    ImageSceneView(imagePath: "/path")
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/TitleSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/TitleSceneView.swift
@@ -1,0 +1,34 @@
+//
+//  TitleSceneView.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/4/25.
+//
+import SwiftUI
+
+/// 일상 시상 제목 서브뷰
+struct TitleSceneView: View {
+    /// 시상 제목
+    var title: String?
+    
+    var body: some View {
+        VStack {
+            if let title {
+                Text("\(title)")
+                    .font(FFYFont.title1)
+                    .foregroundStyle(FFYColor.black)
+                    .lineLimit(2)
+            } else {
+                Text("제목없음")
+                    .font(FFYFont.title1)
+                    .foregroundStyle(FFYColor.black)
+            }
+        }
+        .padding(.top, 33)
+        .padding(.bottom, 15)
+    }
+}
+
+#Preview {
+    TitleSceneView(title: "봄비 내리는 아침")
+}


### PR DESCRIPTION
### 🖥️ 작업 내역

close #57 

> 구현 내용 및 작업 했던 내역을 적어주세요.

- 네비게이션 바 추가 (뒤로가기, 타이틀 적용)
- 네비게이션 바에 더보기 버튼 추가
- 특정 시상에 대한 내용 및 사진을 뷰에 표시
- 해당 시상으로 작성한 시와 개수 표시


<img width="300" alt="Screenshot 2025-06-04 at 12 54 59 PM" src="https://github.com/user-attachments/assets/34c56c3c-4262-4fb4-81be-7401daebb4c8" />