### PR TITLE
✨ [feat] 감상 작성 뷰 UI 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/InspirationInputFieldView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/InspirationInputFieldView.swift
@@ -1,0 +1,42 @@
+//
+//  InspirationInputFieldView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 시상과 감상 입력 필드에서 공통으로 쓰이는 제목과 텍스트필드가 있는 공통 서브뷰 컴포넌트입니다.
+struct InspirationInputFieldView: View {
+    // MARK: - Properties
+    /// 구역 제목
+    let title: String
+    
+    /// 텍스트 에디터에서 수정할 텍스트
+    @Binding var text: String
+    
+    /// placeholder 텍스트
+    let placeholder: String
+    
+    // MARK: - View
+    var body: some View {
+        VStack(spacing: 12) {
+            // 제목
+            Text(title)
+                .font(FFYFont.title3)
+                .foregroundStyle(FFYColor.gray3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            
+            // 텍스트 에디터
+            TwoLineTextEditorView(text: $text, placeholder: placeholder)
+                .padding(.horizontal, -24)
+        }
+    }
+}
+
+#Preview {
+    InspirationInputFieldView(
+        title: "제목", text: .constant(""), placeholder: "여기에뭐라고적어야되는지보여주는텍스트"
+    )
+}

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/TwoLineTextEditorView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/TwoLineTextEditorView.swift
@@ -33,7 +33,7 @@ struct TwoLineTextEditorView: View {
                 .scrollContentBackground(.hidden)
                 .scrollDisabled(true)
         }
-        .frame(height: 55)
+        .frame(height: 80)
         .padding(.leading, 20)
         .padding(.trailing, 24)
     }

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/TwoLineTextEditorView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspirationTextInput/TwoLineTextEditorView.swift
@@ -1,0 +1,53 @@
+//
+//  TwoLineTextEditorView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 기본적으로 쓰이는 2줄까지 입력 가능한 텍스트 에디터 컴포넌트뷰
+struct TwoLineTextEditorView: View {
+    // MARK: - Properties
+    /// 뷰에서 수정할 텍스트
+    @Binding var text: String
+    
+    /// 기본 placeholder 텍스트
+    let placeholder: String
+
+    // MARK: - View
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text(placeholder)
+                    .font(FFYFont.body)
+                    .foregroundStyle(FFYColor.gray2)
+                    .padding(.leading, 4)
+                    .padding(.top, 8)
+            }
+
+            TextEditor(text: limitedText)
+                .font(FFYFont.body)
+                .foregroundColor(.black)
+                .scrollContentBackground(.hidden)
+                .scrollDisabled(true)
+        }
+        .frame(height: 55)
+        .padding(.leading, 20)
+        .padding(.trailing, 24)
+    }
+
+    private var limitedText: Binding<String> {
+        Binding<String>(
+            get: { limitText(text) },
+            set: { newValue in
+                text = limitText(newValue)
+            }
+        )
+    }
+    
+    private func limitText(_ input: String) -> String {
+        String(input.prefix(52))
+    }
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/AppreciationWritingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/AppreciationWritingView.swift
@@ -6,6 +6,7 @@
 //
 import SwiftUI
 
+/// 감상 작성 뷰
 struct AppreciationWritingView: View {
     @StateObject var viewModel: AppreciationWritingViewModel
     
@@ -14,8 +15,34 @@ struct AppreciationWritingView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
+            // 네비게이션 바
+            NavigationBar(
+                title: "감상 쓰기",
+                style: .backTitleButton(
+                    title: "저장하기",
+                    isEnabled: viewModel.state.isSaveEnabled,
+                    action: {
+                        // TODO: 저장하기 버튼 클릭 시점의 데이터 저장과 화면 전환 (ssol)
+                    }
+                )
+            )
             
+            // 작성 콘텐츠 뷰
+            ScrollView {
+                AppreciationWritingContentView(
+                    scene: $viewModel.state.scene,
+                    title: $viewModel.state.title,
+                    content: $viewModel.state.content
+                )
+                .padding(.horizontal, 24)
+                .padding(.top, 30)
+            }
         }
+        .hideKeyboardOnTap()
     }
+}
+
+#Preview {
+    AppreciationWritingView(appreciation: .init(scene: nil, title: nil, content: nil), coordinator: .init())
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/AppreciationWritingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/AppreciationWritingViewModel.swift
@@ -7,10 +7,23 @@
 import Combine
 import SwiftUI
 
+/// 감상 작성 뷰모델
 final class AppreciationWritingViewModel: ViewModelable {
     @ObservedObject var coordinator: Coordinator
     struct State {
         var appreciation: Appreciation?
+        
+        // 화면에서 작성하는 3종 텍스트
+        var scene: String
+        var title: String
+        var content: String
+        
+        // 저장 버튼 활성화 여부: 계산 프로퍼티
+        var isSaveEnabled: Bool {
+            !scene.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
     }
     
     enum Action {
@@ -20,7 +33,17 @@ final class AppreciationWritingViewModel: ViewModelable {
     @Published var state: State
     
     init(appreciation: Appreciation?, coordinator: Coordinator) {
-        self.state = State(appreciation: appreciation)
+        
+        let scene = appreciation?.scene ?? ""
+        let title = appreciation?.title ?? ""
+        let content = appreciation?.content ?? ""
+        
+        self.state = State(
+            appreciation: appreciation,
+            scene: scene,
+            title: title,
+            content: content
+        )
         self.coordinator = coordinator
     }
     

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationContentEditorView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationContentEditorView.swift
@@ -1,0 +1,33 @@
+//
+//  AppreciationContentEditorView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 내 감상 쓰기 서브뷰
+struct AppreciationContentEditorView: View {
+    // MARK: - Properties
+    @Binding var content: String
+    
+    // MARK: - View
+    var body: some View {
+        VStack (spacing: 15) {
+            // 제목이랑 구분선: 내 감상 쓰기
+            AppreciationLayoutView()
+            
+            // 내 감상 쓰기 텍스트 에디터
+            AppreciationContentTextEditorView(
+                text: $content, 
+                placeholder: "시상이 어떤 감정을 떠올리게 하나요?\n\n콘텐츠를 볼 때 나의 기분, 떠오른 생각 등\n나만의 감상을 자세히 기록해요"
+            )
+            .padding(.horizontal, -24)
+        }
+    }
+}
+
+#Preview {
+    AppreciationContentEditorView(content: .constant(""))
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationContentTextEditorView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationContentTextEditorView.swift
@@ -1,0 +1,55 @@
+//
+//  AppreciationContentTextEditorView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 내 감상 쓰기용 텍스트 에디터 서브뷰
+struct AppreciationContentTextEditorView: View {
+    // MARK: - Properties
+    @Binding var text: String
+    var placeholder: String = "시상이 나를 어디로 데려 가나요?\n\n나에게 있었던 일과 그 때의 생각,\n미처 하지 못한 이야기를 자유롭게 기록해요"
+
+    // MARK: - View
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text(placeholder)
+                    .font(FFYFont.body)
+                    .foregroundStyle(FFYColor.gray2)
+                    .padding(.leading, 4)
+                    .padding(.top, 8)
+            }
+
+            TextEditor(text: limitedText)
+                .font(FFYFont.body)
+                .foregroundColor(.black)
+                .scrollContentBackground(.hidden)
+                .scrollDisabled(false)
+        }
+        .frame(height: 340)
+        .padding(.leading, 20)
+        .padding(.trailing, 24)
+    }
+
+    // computed properties
+    private var limitedText: Binding<String> {
+        Binding<String>(
+            get: { limitText(text) },
+            set: { newValue in
+                text = limitText(newValue)
+            }
+        )
+    }
+    
+    private func limitText(_ input: String) -> String {
+        String(input.prefix(500))
+    }
+}
+
+#Preview {
+    AppreciationContentTextEditorView(text: .constant(""))
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationLayoutView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationLayoutView.swift
@@ -1,0 +1,27 @@
+//
+//  AppreciationLayoutView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 내 감상 쓰기랑 구분선 있는 뷰
+struct AppreciationLayoutView: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("내 감상 쓰기")
+                .font(FFYFont.title3)
+                .foregroundStyle(FFYColor.gray3)
+            
+            Rectangle()
+                .frame(maxWidth: .infinity, maxHeight: 1)
+                .foregroundStyle(FFYColor.gray1)
+        }
+    }
+}
+
+#Preview {
+    AppreciationLayoutView()
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationWritingContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationWritingContentView.swift
@@ -1,0 +1,31 @@
+//
+//  AppreciationWritingContentView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 감상 쓰기 텍스트필드 3개 모여있는 전체 뷰
+struct AppreciationWritingContentView: View {
+    // MARK: - Properties
+    @Binding var scene: String
+    @Binding var title: String
+    @Binding var content: String
+    
+    // MARK: - View
+    var body: some View {
+        VStack(spacing: 30) {
+            // 기억에 남는 장면
+            InspirationInputFieldView(title: "기억에 남는 장면", text: $scene, placeholder: "감상한 콘텐츠에서 기억에 남은 장면을 적어요.")
+            
+            // 마음의 한 줄
+            InspirationInputFieldView(title: "마음의 한 줄", text: $title, placeholder: "내 마음에 남은 말과 표정을 시상으로 남겨요")
+            
+            // 내 감상 쓰기
+            AppreciationContentEditorView(content: $content)
+        }
+        
+    }
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationWritingContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationWriting/SubViews/AppreciationWritingContentView.swift
@@ -16,7 +16,7 @@ struct AppreciationWritingContentView: View {
     
     // MARK: - View
     var body: some View {
-        VStack(spacing: 30) {
+        VStack(spacing: 4) {
             // 기억에 남는 장면
             InspirationInputFieldView(title: "기억에 남는 장면", text: $scene, placeholder: "감상한 콘텐츠에서 기억에 남은 장면을 적어요.")
             


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

감상 작성 뷰 UI를 구현했습니다.

<img width="250" alt="스크린샷 2025-06-04 오후 5 49 33" src="https://github.com/user-attachments/assets/fd497b96-4cd7-468a-928d-954c5e868233" />
<img width="250" alt="스크린샷 2025-06-04 오후 5 49 14" src="https://github.com/user-attachments/assets/8a396b22-c19b-42bb-b2a5-1293507d1ce4" />

- 감상 & 시상 공통 텍스트필드(제목과 2줄 입력 텍스트필드) 공통 서브뷰 컴포넌트 구현
- 상단 2종 텍스트 에디터는 52자 제한, 하단 내 감상 쓰기 에디터는 500자 제한으로 작성할 수 있도록 구현
- 3종 텍스트 중 한가지라도 입력되어 있는지 여부에 따라서 저장하기 버튼 활성화 여부 결정

### ✅ 공통 컴포넌트 수정사항
<img width="1279" alt="스크린샷 2025-06-04 오후 9 33 31" src="https://github.com/user-attachments/assets/85a9c009-d513-4e16-ae49-5426ac3e6ce1" />
<img width="1279" alt="스크린샷 2025-06-04 오후 9 33 39" src="https://github.com/user-attachments/assets/bd27db75-b3b5-4388-8227-f93bbb8d7c55" />

기존에 베리가 작업해주셨던 TitleTextEditorView를 기반으로 공통 컴포넌트인 TwoLineTextEditorView를 작업했는데요,
Editor가 포함되어있는 ZStack의 height값이 55일 경우 시뮬레이터에서 확인해봤을 때 
한 줄 이상으로 넘어가면 텍스트가 보이지 않고 잘리는 이슈가 있어서 조금 더 넉넉한 사이즈인 80으로 frame 높이 지정해서 구현해두었습니다! 참고 부탁드립니다~


### 뷰 구조
```
AppreciationWritingView
ㄴ NavigationBar
ㄴ AppreciationWritingContentView(감상 쓰기 뷰 본문 전체)
	ㄴ InspirationInputFieldView(기억에 남는 장면)
	ㄴ InspirationInputFieldView(마음의 한 줄)
	ㄴ AppreciationContentEditorView(내 감상 쓰기)
		ㄴ AppreciationLayoutView(내 감상 쓰기 제목바)
		ㄴ AppreciationContentTextEditorView(내 감상 쓰기 감상평 적는 TextEditor)
```