### PR TITLE
✨ [feat] #60 나의 시집 - 쓰고 있는 시 UI 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionView.swift
@@ -9,14 +9,49 @@ import SwiftUI
 
 struct OngoingCollectionView: View {
     @StateObject var viewModel: OngoingCollectionViewModel
+ 
+    @Environment(\.dismiss) private var dismiss
     
     init(coordinator: Coordinator) {
         _viewModel = StateObject(wrappedValue: OngoingCollectionViewModel(coordinator: coordinator))
     }
     
     var body: some View {
-        VStack {
-            
+     VStack(spacing: 0) {
+      
+      NavigationBar(
+       title: nil,
+       style: .back) {
+         dismiss()
+       }
+  
+          Text("쓰고 있는 시")
+             .font(FFYFont.largeTitle)
+             .foregroundStyle(.black)
+             .frame(maxWidth: .infinity, alignment: .leading)
+             .padding(.horizontal, 24)
+             .padding(.vertical, 20)
+
+         SearchBar(text: $viewModel.state.searchText)
+              .onChange(of: viewModel.state.searchText) {
+                  viewModel.action(.search)
+              }
+         OngoingCollectionListView(
+             poems: viewModel.state.searchedPoems,
+             ongoingPoemTapAction: { poemId in
+                 viewModel.action(.ongoingPoemTapped(poemId))
+             }
+         )
+         .padding(.horizontal, 45)
+        }
+     
+        .onAppear {
+         viewModel.action(.viewAppeared)
         }
     }
+}
+
+
+#Preview {
+ OngoingCollectionView(coordinator: .init())
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
@@ -5,15 +5,21 @@
 //  Created by 한건희 on 5/31/25.
 //
 import Combine
+import SwiftData
 import SwiftUI
 
 final class OngoingCollectionViewModel: ViewModelable {
     @ObservedObject var coordinator: Coordinator
     struct State {
-        
+     var searchText: String = ""
+     var poems: [Poem] = []
+     var searchedPoems: [Poem] = []
     }
     
     enum Action {
+     case viewAppeared
+     case search
+     case ongoingPoemTapped(_ poemId: String)
         
     }
     
@@ -25,7 +31,46 @@ final class OngoingCollectionViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
+        case .viewAppeared:
+            state.poems = setTestPoems()
+            state.searchedPoems = state.poems
             
+        case .search:
+            state.searchedPoems = searchPoems(searchText: state.searchText)
+            
+        case .ongoingPoemTapped(let poemId):
+            // TODO: navigate to poem reading view
+            break
         }
     }
+ 
+ private func fetchOngoingPoems(context: ModelContext) -> [Poem] {
+        switch SwiftDataManager.shared.fetchAllPoemList(context: context) {
+        case .success(let success):
+            return success.filter { !$0.isCompleted }
+            
+        case .failure(let failure):
+            print("Failed to fetch poems:", failure)
+            return []
+        }
+    }
+ 
+ private func searchPoems(searchText: String) -> [Poem] {
+     if searchText.isEmpty {
+         return state.poems
+     }
+     
+     return state.poems.filter {
+         $0.title.contains(searchText) || $0.content.contains(searchText)
+     }
+ }
+ 
+ private func setTestPoems() -> [Poem] {
+     return [
+         Poem(title: "제목은열한글자를넘어가면말줄임표로 생략되어요", content: "쓰고 있는 시에서는 작성 중에 임시저장한 시를 보여 줍니다. 내용 47자를 보여주어 어떤 시를 쓰고 있었는지 확인 할 수 있습니다. 쓰고 있는 시에서는 작성 중에 임시저장한 시를 보여 줍니다. 내용 47자를 보여주어 어떤 시를 쓰고 있었는지 확인 할 수 있습니다."),
+         Poem(title: "", content: "poem nontitle content"),
+         Poem(title: "애순이의 슬픈 눈", content: "(비어있음)"),
+         Poem(title: "poem3", content: "poem3 content")
+     ]
+ }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/SubView/OngoingCollectionListView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/SubView/OngoingCollectionListView.swift
@@ -1,0 +1,34 @@
+//
+//  OngoingCollectionListView.swift
+//  FunForYou
+//
+//  Created by KIM, SoonJoo on 6/4/25.
+//
+
+import SwiftUI
+
+struct OngoingCollectionListView: View {
+    var poems: [Poem]
+    var ongoingPoemTapAction: (String) -> Void
+    
+    var body: some View {
+        ScrollView {
+            Spacer().frame(height: 20)
+            LazyVGrid(columns: [
+                GridItem(.flexible(), alignment: .leading),
+                GridItem(.flexible(), alignment: .trailing)
+            ]) {
+                ForEach(poems, id: \.self) { poem in
+                    PoemPaper(
+                     title: poem.title.isEmpty ? "무제" : poem.title,
+                     content: poem.content.isEmpty ? "내용이 없습니다." : poem.content
+                    )
+                    .onTapGesture {
+                        ongoingPoemTapAction(poem.id)
+                    }
+                    .padding(.bottom, 32)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

나의 시집 - 쓰고 있는 시 View Model 과  시 목록 View 구현.

- 네비게이션 바 추가 (뒤로가기 적용)
- Text 적용: 쓰고 있는 시 (좌측 정렬)
- 검색하기
- 시 목록 2열 scroll
- 쓰고 있는 시 카드 내용 표시
- 카드 밑 제목 표시

<img width="568" alt="스크린샷 2025-06-04 23 36 09" src="https://github.com/user-attachments/assets/2cbd28f3-2f9e-40fb-8e7a-cd8431772788" />
