### PR TITLE
💄 [style] 감상 읽기 뷰 메뉴 커스텀 UI 적용

### DIFF
--- a/FunForYou/FunForYou/Sources/Common/DesignSystem/TopMenuModal.swift
+++ b/FunForYou/FunForYou/Sources/Common/DesignSystem/TopMenuModal.swift
@@ -68,7 +68,7 @@ struct TopMenuModalButton: View {
     @Previewable @State var showModal: Bool = true
     TopMenuModal(
         showModal: $showModal,
-        modalStyle: .appreciationReadingTop(
+        modalStyle: .defaultTop(
             modify: {
                 // modify action
             },

--- a/FunForYou/FunForYou/Sources/Enum/TopModalStyleType.swift
+++ b/FunForYou/FunForYou/Sources/Enum/TopModalStyleType.swift
@@ -13,7 +13,7 @@ enum TopModalStyleType {
         appreciation: () -> Void
     )
     
-    case appreciationReadingTop(
+    case defaultTop(
         modify: () -> Void,
         delete: () -> Void
     )
@@ -23,7 +23,7 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop(let daily, _):
             return daily
-        case .appreciationReadingTop(let modify, _):
+        case .defaultTop(let modify, _):
             return modify
         }
     }
@@ -32,7 +32,7 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop(_, let appreciation):
             return appreciation
-        case .appreciationReadingTop(_, let delete):
+        case .defaultTop(_, let delete):
             return delete
         }
     }
@@ -41,8 +41,8 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop:
             return "일상 이야기에요"
-        case .appreciationReadingTop:
-            return "시상 고치기"
+        case .defaultTop:
+            return "고쳐 쓰기"
         }
     }
     
@@ -50,8 +50,8 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop:
             return "감상한 콘텐츠가 있어요"
-        case .appreciationReadingTop:
-            return "시상 지우기"
+        case .defaultTop:
+            return "지우기"
         }
     }
     
@@ -59,7 +59,7 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop:
             return FFYColor.black
-        case .appreciationReadingTop:
+        case .defaultTop:
             return .blue
         }
     }
@@ -68,7 +68,7 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop:
             return FFYColor.black
-        case .appreciationReadingTop:
+        case .defaultTop:
             return .red
         }
     }
@@ -77,7 +77,7 @@ enum TopModalStyleType {
         switch self {
         case .inspirationTop:
             return 44
-        case .appreciationReadingTop:
+        case .defaultTop:
             return 56
         }
     }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 /// 감상 읽기 뷰
 struct AppreciationReadingView: View {
+    // MARK: - Properties
     @StateObject var viewModel: AppreciationReadingViewModel
     
     @Environment(\.modelContext) var context
     
+    // MARK: - init
     init(appreciation: Appreciation, coordinator: Coordinator) {
         _viewModel = StateObject(wrappedValue: AppreciationReadingViewModel(appreciation: appreciation, coordinator: coordinator))
     }
@@ -20,8 +22,18 @@ struct AppreciationReadingView: View {
     // MARK: - View
     var body: some View {
         VStack(spacing: 0) {
-            // 네비게이션 바
-            AppreciationReadingNavigationBar()
+            // 네비게이션 바 영역
+            AppreciationReadingTopView(
+                ellipseButtonTapAction: { viewModel.action(.ellipseButtonTapAction)
+                },
+                editButtonTapAction: {
+                    viewModel.action(.editButtonTapAction)
+                },
+                deleteButtonTapAction: {
+                    viewModel.action(.deleteButtonTapAction)
+                },
+                showModal: $viewModel.state.showModal
+            )
             
             ScrollView {
                 // 감상 본문
@@ -41,6 +53,10 @@ struct AppreciationReadingView: View {
                 .padding(.top, 64)
                 .padding(.horizontal, 24)
             }
+        }
+        .onTapGesture {
+            // 메뉴 외의 다른 영역 터치할 때 메뉴 없어지도록
+            viewModel.action(.menuDisappearAction)
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingViewModel.swift
@@ -7,6 +7,7 @@
 import Combine
 import SwiftUI
 
+/// 감상 읽기 뷰모델
 final class AppreciationReadingViewModel: ViewModelable {
     @ObservedObject var coordinator: Coordinator
     struct State {
@@ -15,10 +16,20 @@ final class AppreciationReadingViewModel: ViewModelable {
         
         /// 이 시상으로 지은 시 배열
         var inspiredPoems: [Poem] = []
+        
+        /// 네비게이션 메뉴 보여주기 결정
+        var showModal: Bool = false
     }
     
     enum Action {
-        
+        /// 상단 메뉴 띄우기
+        case ellipseButtonTapAction
+        /// 메뉴 없어지게 하기
+        case menuDisappearAction
+        /// 감상 편집
+        case editButtonTapAction
+        /// 감상 지우기
+        case deleteButtonTapAction
     }
     
     @Published var state: State
@@ -30,7 +41,19 @@ final class AppreciationReadingViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
+        case .ellipseButtonTapAction:
+            state.showModal.toggle()
             
+        case .menuDisappearAction:
+            state.showModal = false
+            
+        case .editButtonTapAction:
+            // TODO: 시상 수정하기 화면으로 연결(ssol)
+            print("시상 수정하기 화면으로 연결")
+            
+        case .deleteButtonTapAction:
+            // TODO: 시상 삭제 alert 띄우기(ssol)
+            print("시상 삭제 alert 띄우기")
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
@@ -10,24 +10,18 @@ import SwiftUI
 /// 감상 읽기 페이지의 네비게이션 바
 /// - 우측 ellipse 버튼 누르면 고쳐 쓰기, 지우기 메뉴 띄우고 기능 연결(예정)
 struct AppreciationReadingNavigationBar: View {
+    // MARK: - Properties
+    /// ellipse 버튼 눌릴 때 액션(모달 띄우는 bool 변경시키기)
+    var ellipseButtonTapAction: () -> Void
+        
+    // MARK: - View
     var body: some View {
         ZStack(alignment: .trailing) {
             NavigationBar(title: "감상 읽기", style: .backTitle)
             
-            Menu {
-                // 고쳐 쓰기
-                Button {
-                    // TODO: 감상 편집 페이지로 이동(ssol)
-                } label: {
-                    Text("고쳐 쓰기")
-                }
-                
-                // 지우기
-                Button(role: .destructive) {
-                    // TODO: 정말 지우겠냐는 alert 띄우고 액션 연결하기(ssol)
-                } label: {
-                    Text("지우기")
-                }
+            Button {
+                // 모달 띄우기
+                ellipseButtonTapAction()
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.title3)
@@ -41,5 +35,5 @@ struct AppreciationReadingNavigationBar: View {
 }
 
 #Preview {
-    AppreciationReadingNavigationBar()
+    AppreciationReadingNavigationBar(ellipseButtonTapAction: {})
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
@@ -1,0 +1,59 @@
+//
+//  AppreciationReadingTopView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 감상 읽기 네비게이션 바 + 커스텀 메뉴(모달)
+struct AppreciationReadingTopView: View {
+    // MARK: - Properties
+    var ellipseButtonTapAction: () -> Void
+    var editButtonTapAction: () -> Void
+    var deleteButtonTapAction: () -> Void
+    @Binding var showModal: Bool
+    
+    // MARK: - init
+    init(
+        ellipseButtonTapAction: @escaping () -> Void,
+        editButtonTapAction: @escaping () -> Void,
+        deleteButtonTapAction: @escaping () -> Void,
+        showModal: Binding<Bool>
+    ) {
+        self.ellipseButtonTapAction = ellipseButtonTapAction
+        self.editButtonTapAction = editButtonTapAction
+        self.deleteButtonTapAction = deleteButtonTapAction
+        self._showModal = showModal
+    }
+    
+    // MARK: - View
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            // 네비게이션 바
+            AppreciationReadingNavigationBar(ellipseButtonTapAction: ellipseButtonTapAction)
+            
+            // 메뉴 모달
+            TopMenuModal(
+                showModal: $showModal,
+                modalStyle: .defaultTop(
+                    modify: {
+                        editButtonTapAction()
+                    },
+                    delete: {
+                        deleteButtonTapAction()
+                    }
+                )
+            )
+            .padding(.horizontal, 20)
+        }
+        .frame(height: 35, alignment: .top)
+        .zIndex(100)
+    }
+
+}
+
+#Preview {
+    AppreciationReadingTopView(ellipseButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {}, showModal: .constant(true))
+}


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
1. 모달 네이밍 변경
- 시상 고치기 & 시상 지우기 -> 고쳐 쓰기 & 지우기로 변경했습니다
- 위 변경사항을 반영하니까 처음 만드실 때 appreciationReadingTop 으로 지어두신 이름보다는 전역적으로 사용하면 좋을 것 같아서 defaultTop으로 case 이름 변경해서 적용, 사용했습니다


2. 감상읽기 뷰에 커스텀 메뉴 모달 적용
<img width="467" alt="스크린샷 2025-06-05 오전 12 22 05" src="https://github.com/user-attachments/assets/8e62f860-4ba5-43c2-9663-e5cd47552c4c" />

- 편할 것 같아서 넣어둔 약간의 추가기능) ellipse 버튼 다시 안 누르고 메뉴 밖 다른 화면 부분 터치해도 메뉴 disappear되는 로직도 추가해서 적용해두었습니닷