### PR TITLE
✨ [feat] 끝맺은 시 읽기 - 끝맺은 시 읽기 뷰 UI 및 로직 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
@@ -13,10 +13,81 @@ struct PoemReadingView: View {
     init(poem: Poem, coordinator: Coordinator) {
         _viewModel = StateObject(wrappedValue: PoemReadingViewModel(poem: poem, coordinator: coordinator))
     }
-    
+
     var body: some View {
-        VStack {
-            
+        ZStack {
+            VStack(spacing: 0) {
+
+                // TODO: 시 제목, 내용을 볼 수 있게 한다.
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text(viewModel.state.poem.title)
+                            .font(FFYFont.title)
+
+                        // TODO: 시 제목과 내용 사이에 작성자 이름(조 연화)이 보이도록 한다.
+                        Text("조 연화")
+                            .font(FFYFont.book)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+
+                        Text(viewModel.state.poem.content)
+                            .font(FFYFont.book)
+
+                        Rectangle()
+                            .frame(maxWidth: .infinity, maxHeight: 0.5)
+                            .padding(.top, 64)
+
+                        // TODO: 흰색 시 프레임 하단 왼쪽에 몇 번째 끝맺은 시인지 보이는 번호를, 하단 오른쪽에 최종수정일을 보여준다.
+                        HStack {
+                            Text("13")
+                            Spacer()
+                            Text("25년 5월 27일")
+                        }
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 48)
+                    .background(
+                        Color(.white))
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 24)
+                }
+                .background(
+                    LinearGradient(
+                        stops: [
+                            Gradient.Stop(color: Color(.pinkLight), location: 0.30),
+                            Gradient.Stop(color: Color(.green), location: 1.00),
+                        ],
+                        startPoint: UnitPoint(x: 0.02, y: 0.01),
+                        endPoint: UnitPoint(x: 1, y: 1)
+                    )
+                )
+            }
         }
     }
+}
+
+private let samplePoem = Poem(
+    title: "바닷가에 대하여",
+    content: """
+    누구나 바닷가 하나씩은 자기만의 바닷가가 있는 게 좋다
+    누구나 바닷가 하나씩은 언제나 찾아갈 수 있는
+    자기만의 바닷가가 있는 게 좋다
+    잠자는 지구의 고요한 숨소리를 듣고 싶을 때
+    지구 위를 걸어가는 새들의 작은 발소리를 듣고 싶을 때
+    새들과 함께 수평선 위로 걸어가고 싶을 때
+    바닷가 기슭으로만 기슭으로만 끝없이 달려가고 싶을 때
+    누구나 자기만의 바닷가가 하나씩 있으면 좋다
+    자기만의 바닷가로 달려가 쓰러지는 게 좋다 
+    """,
+    date: Date()
+)
+
+private let dummyCoordinator = Coordinator()
+
+#Preview {
+    PoemReadingView(poem: samplePoem, coordinator: dummyCoordinator)
+//        .frame(maxWidth: .infinity, maxHeight: .infinity) // 전체 화면 채우기
+//        .previewLayout(.sizeThatFits) // 크기 설정
+//        .ignoresSafeArea() // SafeArea 안 가리고 그라디언트 끝까지 보이게
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
@@ -4,12 +4,13 @@
 //
 //  Created by 한건희 on 5/31/25.
 //
-
+import SwiftData
 import SwiftUI
 
 struct PoemReadingView: View {
     @StateObject var viewModel: PoemReadingViewModel
-    
+    @Environment(\.modelContext) private var context
+
     init(poem: Poem, coordinator: Coordinator) {
         _viewModel = StateObject(wrappedValue: PoemReadingViewModel(poem: poem, coordinator: coordinator))
     }
@@ -17,6 +18,15 @@ struct PoemReadingView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
+                PoemReadingTopView(ellipseButtonTapAction: { viewModel.action(.ellipseButtonTapAction)
+                                   },
+                                   editButtonTapAction: {
+                                       viewModel.action(.editButtonTapAction)
+                                   },
+                                   deleteButtonTapAction: {
+                                       viewModel.action(.deleteButtonTapAction(context: context))
+                                   },
+                                   showModal: $viewModel.state.showModal)
 
                 // TODO: 시 제목, 내용을 볼 수 있게 한다.
                 ScrollView {

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingViewModel.swift
@@ -6,27 +6,63 @@
 //
 import Combine
 import SwiftUI
+import SwiftData
 
 final class PoemReadingViewModel: ViewModelable {
     @ObservedObject var coordinator: Coordinator
     struct State {
         var poem: Poem
+        /// 네비게이션 메뉴 보여주기 결정
+        var showModal: Bool = false
     }
-    
+
     enum Action {
-        
+        case ellipseButtonTapAction
+        /// 메뉴 없어지게 하기
+        case menuDisappearAction
+        /// 끝맺은 시  편집
+        case editButtonTapAction
+        /// 끝맺은 시  지우기
+        case deleteButtonTapAction(context: ModelContext)
+
     }
-    
+
     @Published var state: State
-    
+
     init(poem: Poem, coordinator: Coordinator) {
         self.state = State(poem: poem)
         self.coordinator = coordinator
     }
-    
+
     func action(_ action: Action) {
         switch action {
+        case .ellipseButtonTapAction:
+            state.showModal.toggle()
+
+        case .menuDisappearAction:
+            state.showModal = false
+
+        case .editButtonTapAction:
+            // TODO: 시 수정하기 화면으로 연결(Yeony)
+            print("시 수정하기 화면으로 연결")
+            print("\(state.poem.title)")
+            coordinator.push(.poemWriting(state.poem))
+
+        case .deleteButtonTapAction(let context):
+            // TODO: 시 삭제 alert 띄우기(Yeony)
+            print("시 삭제 alert 띄우기")
+            print("삭제 poem: \(state.poem.title)")
+            let result = SwiftDataManager.shared.deletePoem(poem: state.poem, context: context)
+            switch result {
+            case .success:
+                print("삭제 성공")
+                ///Todo : 끝맺은 시 뷰로 이동
+                coordinator.removeAll()
             
+            case .failure(let error):
+                print("시 삭제 실패: ",error.localizedDescription)
+            }
+
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
@@ -1,0 +1,39 @@
+//
+//  AppreciationReadingNavigationBar.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/3/25.
+//
+
+import SwiftUI
+
+/// 시  읽기 페이지의 네비게이션 바
+/// - 우측 ellipse 버튼 누르면 고쳐 쓰기, 지우기 메뉴 띄우고 기능 연결(예정)
+struct PoemReadingNavigationBar: View {
+    // MARK: - Properties
+    /// ellipse 버튼 눌릴 때 액션(모달 띄우는 bool 변경시키기)
+    var ellipseButtonTapAction: () -> Void
+        
+    // MARK: - View
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            NavigationBar(title: "시 낭독하기", style: .backTitle)
+            
+            Button {
+                // 모달 띄우기
+                ellipseButtonTapAction()
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.title3)
+                    .foregroundStyle(FFYColor.pinkDark)
+                    .padding(.bottom)
+                    .padding(.trailing, 24)
+            }
+
+        }
+    }
+}
+
+#Preview {
+    PoemReadingNavigationBar(ellipseButtonTapAction: {})
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingTopView.swift
@@ -1,0 +1,61 @@
+//
+//  AppreciationReadingTopView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/4/25.
+//
+
+import SwiftUI
+
+/// 시  읽기 네비게이션 바 + 커스텀 메뉴(모달)
+struct PoemReadingTopView: View {
+    // MARK: - Properties
+
+    var ellipseButtonTapAction: () -> Void
+    var editButtonTapAction: () -> Void
+    var deleteButtonTapAction: () -> Void
+    @Binding var showModal: Bool
+
+    // MARK: - init
+
+    init(
+        ellipseButtonTapAction: @escaping () -> Void,
+        editButtonTapAction: @escaping () -> Void,
+        deleteButtonTapAction: @escaping () -> Void,
+        showModal: Binding<Bool>
+    ) {
+        self.ellipseButtonTapAction = ellipseButtonTapAction
+        self.editButtonTapAction = editButtonTapAction
+        self.deleteButtonTapAction = deleteButtonTapAction
+        self._showModal = showModal
+    }
+
+    // MARK: - View
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            // 네비게이션 바
+            PoemReadingNavigationBar(ellipseButtonTapAction: ellipseButtonTapAction)
+
+            // 메뉴 모달
+            TopMenuModal(
+                showModal: $showModal,
+                modalStyle: .defaultTop(
+                    modify: {
+                        editButtonTapAction()
+                    },
+                    delete: {
+                        deleteButtonTapAction()
+                    }
+                )
+            )
+            .padding(.horizontal, 20)
+        }
+        .frame(height: 33, alignment: .top)
+        .zIndex(100)
+    }
+}
+
+#Preview {
+    PoemReadingTopView(ellipseButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {}, showModal: .constant(true))
+}


### PR DESCRIPTION
### Issue Number
close #70

### 🖥️ 작업 내역

> 끝맺은 시 읽기 뷰 UI 및 로직 구현했습니다.

- 배경 2색 그라디언트를 넣는다.
- 시 제목, 내용을 볼 수 있게 한다.
- 시 제목과 내용 사이에 작성자 이름(조 연화)이 보이도록 한다.
- 좌상단 뒤로가기와 우상단 옵션메뉴(고쳐 쓰기/지우기)가 있는 시 낭독하기 내비게이션 바를 넣는다.
- 흰색 시 프레임 하단 왼쪽에 몇 번째 끝맺은 시인지 보이는 번호를 보여준다.
- 흰색 시 프레임 하단 오른쪽에 최종수정일을 보여준다.
- 시 낭독하기 내비게이션 바, 탑뷰 액션 구현
- 시 낭독하기 뷰모델 로직 구현

쓰고 있는 시 읽기 뷰(내비게이션, 탑 모달 포함) 로직은  우디에게..

<img width="353" alt="Screenshot 2025-06-05 at 1 00 34 PM" src="https://github.com/user-attachments/assets/3ceefed5-63fe-4904-a709-551b0ebba75f" />

