### PR TITLE
✨ [feat] 감상 읽기 뷰 기능 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsGridView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsGridView.swift
@@ -18,8 +18,8 @@ struct InspiredPoemCardsGridView: View {
     
     /// 2열 그리드
     let columns = [
-        GridItem(.flexible(), alignment: .leading),
-        GridItem(.flexible(), alignment: .trailing)
+        GridItem(.flexible(), alignment: .topLeading),
+        GridItem(.flexible(), alignment: .topTrailing)
     ]
     
     // MARK: - View
@@ -43,9 +43,6 @@ struct InspiredPoemCardsGridView: View {
     InspiredPoemCardsGridView(
         inspirationID: "",
         poems: [
-            .init(title: "무제", content: ""),
-            .init(title: "무제", content: ""),
-            .init(title: "무제", content: ""),
             .init(title: "무제", content: ""),
             .init(title: "무제", content: ""),
             .init(title: "무제", content: "")

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsGridView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsGridView.swift
@@ -22,18 +22,25 @@ struct InspiredPoemCardsGridView: View {
         GridItem(.flexible(), alignment: .topTrailing)
     ]
     
+    /// 해당 시상 가지고 새로운 시 쓰는 화면으로 이동하기
+    var writeNewPoemButtonTapAction: () -> Void
+    /// 누르면 해당 시 조회 화면으로 이동
+    var readPoemButtonTapAction: (Poem) -> Void
+    
     // MARK: - View
     var body: some View {
         LazyVGrid(columns: columns, spacing: 32) {
             // 새로운 시 추가 버튼
             WritePoem {
-                // TODO: 해당 시상 가지고 새로운 시 쓰는 화면으로 이동하기(ssol)
+                writeNewPoemButtonTapAction()
             }
             
             // 시집 리스트
             ForEach(poems, id: \.self) { poem in
-                // TODO: 누르면 해당 시 조회 화면으로 이동(ssol)
                 PoemBook(title: poem.title, date: poem.date)
+                    .onTapGesture {
+                        readPoemButtonTapAction(poem)
+                    }
             }
         }
     }
@@ -46,7 +53,9 @@ struct InspiredPoemCardsGridView: View {
             .init(title: "무제", content: ""),
             .init(title: "무제", content: ""),
             .init(title: "무제", content: "")
-        ]
+        ],
+        writeNewPoemButtonTapAction: {},
+        readPoemButtonTapAction: {_ in }
     )
     .padding(.horizontal, 15)
     .padding(.horizontal, 24)

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsView.swift
@@ -16,6 +16,9 @@ struct InspiredPoemCardsView: View {
     /// 해당 시상으로 쓴 시들
     let poems: [Poem]
     
+    var writeNewPoemButtonTapAction: () -> Void
+    var readPoemButtonTapAction: (Poem) -> Void
+    
     // MARK: - View
     var body: some View {
         VStack (spacing: 20) {
@@ -25,7 +28,9 @@ struct InspiredPoemCardsView: View {
             // 시집 카드 그리드
             InspiredPoemCardsGridView(
                 inspirationID: self.inspirationID,
-                poems: self.poems
+                poems: self.poems,
+                writeNewPoemButtonTapAction: writeNewPoemButtonTapAction,
+                readPoemButtonTapAction: readPoemButtonTapAction
             )
             .padding(.horizontal, 15)
         }
@@ -43,6 +48,8 @@ struct InspiredPoemCardsView: View {
             .init(title: "무제", content: ""),
             .init(title: "무제", content: ""),
             .init(title: "무제", content: "")
-        ]
+        ],
+        writeNewPoemButtonTapAction: {},
+        readPoemButtonTapAction: {_ in }
     )
 }

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemCardsView.swift
@@ -20,17 +20,7 @@ struct InspiredPoemCardsView: View {
     var body: some View {
         VStack (spacing: 20) {
             // 섹션 제목 바
-            HStack(alignment: .center) {
-                Text("이 시상으로 지은 시")
-                    .font(FFYFont.title3)
-                    .foregroundStyle(FFYColor.pinkDark)
-                
-                Spacer()
-                
-                Text("\(poems.count)편")
-                    .font(FFYFont.body)
-                    .foregroundStyle(FFYColor.gray2)
-            }
+            InspiredPoemLayoutView(poemCount: poems.count)
             
             // 시집 카드 그리드
             InspiredPoemCardsGridView(

--- a/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemLayoutView.swift
+++ b/FunForYou/FunForYou/Sources/Common/SubView/InspiredPoemCards/InspiredPoemLayoutView.swift
@@ -1,0 +1,34 @@
+//
+//  InspiredPoemLayoutView.swift
+//  FunForYou
+//
+//  Created by 석민솔 on 6/5/25.
+//
+
+import SwiftUI
+
+/// 이 시상으로 지은 시 제목 바
+struct InspiredPoemLayoutView: View {
+    // MARK: - Properties
+    let poemCount: Int
+    
+    // MARK: - View
+    var body: some View {
+        // 섹션 제목 바
+        HStack(alignment: .center) {
+            Text("이 시상으로 지은 시")
+                .font(FFYFont.title3)
+                .foregroundStyle(FFYColor.pinkDark)
+            
+            Spacer()
+            
+            Text("\(poemCount)편")
+                .font(FFYFont.body)
+                .foregroundStyle(FFYColor.gray2)
+        }
+    }
+}
+
+#Preview {
+    InspiredPoemLayoutView(poemCount: 4)
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
@@ -24,7 +24,11 @@ struct AppreciationReadingView: View {
         VStack(spacing: 0) {
             // 네비게이션 바 영역
             AppreciationReadingTopView(
-                ellipseButtonTapAction: { viewModel.action(.ellipseButtonTapAction)
+                backButtonTapAction: {
+                    viewModel.action(.backButtonTapAction)
+                },
+                ellipseButtonTapAction: {
+                    viewModel.action(.ellipseButtonTapAction)
                 },
                 editButtonTapAction: {
                     viewModel.action(.editButtonTapAction)
@@ -48,15 +52,41 @@ struct AppreciationReadingView: View {
                 // 이 시상으로 지은 시들 리스트
                 InspiredPoemCardsView(
                     inspirationID: viewModel.state.appreciation.id,
-                    poems: viewModel.state.inspiredPoems
+                    poems: viewModel.state.inspiredPoems,
+                    writeNewPoemButtonTapAction: { viewModel.action(.writeNewPoemButtonTapped)
+                    },
+                    readPoemButtonTapAction: { poem in
+                        viewModel.action(.readPoemButtonTapped(poem))
+                    }
                 )
                 .padding(.top, 64)
                 .padding(.horizontal, 24)
             }
         }
+        .overlay {
+            // 읽고 있던 시상을 지울까요? alert
+            if viewModel.state.showAlert {
+                PrimaryAlert(
+                    style: .deleteInspiration,
+                    onPrimary: {
+                        // "아니요, 계속 볼래요"
+                        viewModel.state.showAlert = false
+                    },
+                    onSecondary: {
+                        // "네, 수첩에서 지울게요"
+                        viewModel.action(.deleteAppreciation(context))
+                    },
+                    isVisible: $viewModel.state.showAlert
+                )
+            }
+        }
         .onTapGesture {
             // 메뉴 외의 다른 영역 터치할 때 메뉴 없어지도록
             viewModel.action(.menuDisappearAction)
+        }
+        .onAppear {
+            // 시상으로 지은 시 불러오기
+            viewModel.action(.fetchAllPoemFromInspirationId(context))
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
@@ -11,13 +11,18 @@ import SwiftUI
 /// - 우측 ellipse 버튼 누르면 고쳐 쓰기, 지우기 메뉴 띄우고 기능 연결(예정)
 struct AppreciationReadingNavigationBar: View {
     // MARK: - Properties
+    /// 화면 dismiss시키기
+    var backButtonTapAction: () -> Void
+    
     /// ellipse 버튼 눌릴 때 액션(모달 띄우는 bool 변경시키기)
     var ellipseButtonTapAction: () -> Void
         
     // MARK: - View
     var body: some View {
         ZStack(alignment: .trailing) {
-            NavigationBar(title: "감상 읽기", style: .backTitle)
+            NavigationBar(title: "감상 읽기", style: .backTitle) {
+                backButtonTapAction()
+            }
             
             Button {
                 // 모달 띄우기
@@ -35,5 +40,5 @@ struct AppreciationReadingNavigationBar: View {
 }
 
 #Preview {
-    AppreciationReadingNavigationBar(ellipseButtonTapAction: {})
+    AppreciationReadingNavigationBar(backButtonTapAction: {}, ellipseButtonTapAction: {})
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// 감상 읽기 네비게이션 바 + 커스텀 메뉴(모달)
 struct AppreciationReadingTopView: View {
     // MARK: - Properties
+    var backButtonTapAction: () -> Void
     var ellipseButtonTapAction: () -> Void
     var editButtonTapAction: () -> Void
     var deleteButtonTapAction: () -> Void
@@ -17,11 +18,13 @@ struct AppreciationReadingTopView: View {
     
     // MARK: - init
     init(
+        backButtonTapAction: @escaping () -> Void,
         ellipseButtonTapAction: @escaping () -> Void,
         editButtonTapAction: @escaping () -> Void,
         deleteButtonTapAction: @escaping () -> Void,
         showModal: Binding<Bool>
     ) {
+        self.backButtonTapAction = backButtonTapAction
         self.ellipseButtonTapAction = ellipseButtonTapAction
         self.editButtonTapAction = editButtonTapAction
         self.deleteButtonTapAction = deleteButtonTapAction
@@ -32,7 +35,10 @@ struct AppreciationReadingTopView: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
             // 네비게이션 바
-            AppreciationReadingNavigationBar(ellipseButtonTapAction: ellipseButtonTapAction)
+            AppreciationReadingNavigationBar(
+                backButtonTapAction: backButtonTapAction,
+                ellipseButtonTapAction: ellipseButtonTapAction
+            )
             
             // 메뉴 모달
             TopMenuModal(
@@ -55,5 +61,5 @@ struct AppreciationReadingTopView: View {
 }
 
 #Preview {
-    AppreciationReadingTopView(ellipseButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {}, showModal: .constant(true))
+    AppreciationReadingTopView(backButtonTapAction: {}, ellipseButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {}, showModal: .constant(true))
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
@@ -33,7 +33,13 @@ struct DailyReadingView: View {
                 
                 InspiredPoemCardsView(
                     inspirationID: viewModel.state.daily.id,
-                    poems: viewModel.state.inspiredPoems
+                    poems: viewModel.state.inspiredPoems,
+                    writeNewPoemButtonTapAction: {
+                        viewModel.action(.writeNewPoemButtonTapAction)
+                    },
+                    readPoemButtonTapAction: { poem in
+                        viewModel.action(.readPoemButtonTapAction(poem))
+                    }
                 )
                 .padding(.top, 64)
                 .padding(.horizontal, 24)


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
### ✅ 공통 서브뷰 컴포넌트 `InspiredPoemCardsView` 화면 연결 로직 구현
<img width="460" alt="스크린샷 2025-06-06 오전 3 22 34" src="https://github.com/user-attachments/assets/1760ee5d-f797-4220-83ba-2630d0b9ae50" />

- 클로저 프로퍼티 추가
  - 시 추가하기 카드 → 시 작성 페이지
  - 시집 버튼 → 시 읽기 페이지
- AppreciationReading에서만 사용되는 화면이 아니라 일상 읽기에서도 쓰이는 화면이라서 DailyReadingView와 DailyReadingViewModel에도 수정이 일어났습니다 ⚠️


### ✅ 감상 읽기 뷰 기능 구현

https://github.com/user-attachments/assets/976d8248-991b-4fcb-beca-7d8f28156a1e

- onAppear 시점에 해당 시상으로 지은 시 배열 fetch 

- 네비게이션 버튼 액션 연결
    - 이전 화면으로 dismiss

    - 고쳐쓰기: 해당 감상 편집 화면으로 이동

    - 시상 지우기: 경고 alert띄우고 swiftData에서 지우고 화면 빠져나가기

- 화면 연결 구현: 이 시상으로 지은 시 서브뷰 화면 연결 로직 구현
