### PR TITLE
✨ [feat] 시상 수첩 UI, 나의 시집 - 끝맺은 시 UI 네비게이팅 구현

### DIFF
--- a/FunForYou/FunForYou/Resources/GoogleService-Info.plist
+++ b/FunForYou/FunForYou/Resources/GoogleService-Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyBLVbilvXSbHGBhiTvb0POKSAo1F9urhAo</string>
+	<key>GCM_SENDER_ID</key>
+	<string>689889477562</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.ADA.FunForYou</string>
+	<key>PROJECT_ID</key>
+	<string>funforyou-4f567</string>
+	<key>STORAGE_BUCKET</key>
+	<string>funforyou-4f567.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:689889477562:ios:ccf8751ecd2e155e141383</string>
+	<key>DATABASE_URL</key>
+	<string>https://funforyou-4f567-default-rtdb.firebaseio.com</string>
+</dict>
+</plist>

--- a/FunForYou/FunForYou/Sources/App/Coordinator.swift
+++ b/FunForYou/FunForYou/Sources/App/Coordinator.swift
@@ -29,7 +29,7 @@ enum Path: Hashable {
     case inspirationNote
     case completeCollection
     case ongoingCollection
-    case dailyWriting(String)
+    case dailyWriting(String?)
     case dailyReading(String)
     case appreciationWriting(Appreciation?)
     case appreciationReading(Appreciation)

--- a/FunForYou/FunForYou/Sources/App/FunForYouApp.swift
+++ b/FunForYou/FunForYou/Sources/App/FunForYouApp.swift
@@ -12,6 +12,7 @@ struct FunForYouApp: App {
     @StateObject var coordinator = Coordinator()
     @State var isSplashing: Bool = true
     
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
             ZStack {

--- a/FunForYou/FunForYou/Sources/DB/SwiftDataManager.swift
+++ b/FunForYou/FunForYou/Sources/DB/SwiftDataManager.swift
@@ -57,10 +57,13 @@ final class SwiftDataManager {
         inspirationId: String,
         context: ModelContext
     ) -> Result<[Poem], Error> {
-        let predicate = #Predicate<Poem> { $0.type.id == inspirationId }
-        let fetchDescriptor = FetchDescriptor(predicate: predicate)
+        let predicate = #Predicate<Poem>() { $0.type.id == inspirationId }
+        let fetchDescriptor = FetchDescriptor<Poem>()
         do {
-            let poemList = try context.fetch(fetchDescriptor)
+            var poemList = try context.fetch(fetchDescriptor)
+            poemList = poemList.filter {
+                $0.type.id == inspirationId
+            }
             return .success(poemList)
         } catch {
             return .failure(error)

--- a/FunForYou/FunForYou/Sources/FirebaseFunction/package-lock.json
+++ b/FunForYou/FunForYou/Sources/FirebaseFunction/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "FirebaseFunction",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionView.swift
@@ -14,6 +14,7 @@ struct CompleteCollectionView: View {
         _viewModel = StateObject(wrappedValue: CompleteCollectionViewModel(coordinator: coordinator))
     }
     
+    @Environment(\.modelContext) var context
     var body: some View {
         VStack {
             CompleteCollectionTopView(writePoemButtonTapAction: {
@@ -32,13 +33,13 @@ struct CompleteCollectionView: View {
                     viewModel.action(.continueWriteButtonTapped)
                 },
                 ongoingPoemCount: viewModel.state.ongoingPoemCount,
-                completePoemTapAction: { poemId in
-                    viewModel.action(.completePoemTapped(poemId))
+                completePoemTapAction: { poem in
+                    viewModel.action(.completePoemTapped(poem))
                 }
             )
         }
         .onAppear {
-            viewModel.action(.viewAppeared)
+            viewModel.action(.viewAppeared(context))
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionViewModel.swift
@@ -18,11 +18,11 @@ final class CompleteCollectionViewModel: ViewModelable {
     }
     
     enum Action {
-        case viewAppeared
+        case viewAppeared(ModelContext)
         case writePoemButtonTapped
         case search
         case continueWriteButtonTapped
-        case completePoemTapped(_ poemId: String)
+        case completePoemTapped(_ poem: Poem)
     }
     
     @Published var state: State = State()
@@ -33,12 +33,11 @@ final class CompleteCollectionViewModel: ViewModelable {
     
     func action(_ action: Action) {
         switch action {
-        case .viewAppeared:
-            state.poems = setTestPoems()
+        case .viewAppeared(let context):
+            state.poems = fetchCompletedPoems(context: context)
             state.searchedPoems = state.poems
             
         case .writePoemButtonTapped:
-            // TODO: navigate to write poem view
             coordinator.push(.poemWriting(nil))
             break
         case .search:
@@ -46,9 +45,10 @@ final class CompleteCollectionViewModel: ViewModelable {
             
         case .continueWriteButtonTapped:
             // TODO: navigate to ongoing poem list view
+            coordinator.push(.ongoingCollection)
             break
-        case .completePoemTapped(let poemId):
-            // TODO: navigate to poem reading view
+        case .completePoemTapped(let poem):
+            coordinator.push(.poemReading(poem))
             break
         }
     }

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionListView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionListView.swift
@@ -11,7 +11,7 @@ struct CompleteCollectionListView: View {
     var poems: [Poem]
     var continueWriteButtonTapAction: () -> Void
     var ongoingPoemCount: Int
-    var completePoemTapAction: (String) -> Void
+    var completePoemTapAction: (Poem) -> Void
     
     var body: some View {
         ScrollView {
@@ -31,7 +31,7 @@ struct CompleteCollectionListView: View {
                         date: poem.date
                     )
                     .onTapGesture {
-                        completePoemTapAction(poem.id)
+                        completePoemTapAction(poem)
                     }
                     .padding(.bottom, 32)
                 }

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
@@ -52,6 +52,9 @@ struct InspirationNoteView: View {
         .onAppear {
             viewModel.action(.viewAppeared(context))
         }
+        .onDisappear {
+            viewModel.action(.viewDisappeared)
+        }
         .hideKeyboardOnTap()
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
@@ -39,11 +39,20 @@ struct InspirationNoteView: View {
                     viewModel.action(.search)
                 }
             
-            InspirationPreviewList(inspirations: viewModel.state.searchedInspirations)
+            InspirationPreviewList(
+                inspirations: viewModel.state.searchedInspirations,
+                dailyPreviewTapAction: { id in
+                    viewModel.action(.dailyPreviewTapped(id))
+                },
+                appreciationPreviewTapAction: { appreciation in
+                    viewModel.action(.appreciationPreviewTapped(appreciation))
+                }
+            )
         }
         .onAppear {
             viewModel.action(.viewAppeared(context))
         }
+        .hideKeyboardOnTap()
     }
 }
 

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
@@ -26,6 +26,7 @@ final class InspirationNoteViewModel: ViewModelable {
     
     enum Action {
         case viewAppeared(ModelContext)
+        case viewDisappeared
         case writeInspirationButtonTapped
         case writeDailyButtonTapped
         case writeAppreciationButtonTapped
@@ -46,6 +47,9 @@ final class InspirationNoteViewModel: ViewModelable {
             // TODO: 뷰 보여질 때 SwiftDataManager로부터 inspiration 가져오기
             state.inspirations = fetchInspirations(context: context)
             state.searchedInspirations = state.inspirations
+            
+        case .viewDisappeared:
+            state.showWriteModal = false
             
         case .writeInspirationButtonTapped:
             state.showWriteModal.toggle()

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
@@ -29,6 +29,8 @@ final class InspirationNoteViewModel: ViewModelable {
         case writeInspirationButtonTapped
         case writeDailyButtonTapped
         case writeAppreciationButtonTapped
+        case dailyPreviewTapped(String)
+        case appreciationPreviewTapped(Appreciation)
         case search
     }
     
@@ -42,7 +44,7 @@ final class InspirationNoteViewModel: ViewModelable {
         switch action {
         case .viewAppeared(let context):
             // TODO: 뷰 보여질 때 SwiftDataManager로부터 inspiration 가져오기
-            state.inspirations = setTestInspirations()
+            state.inspirations = fetchInspirations(context: context)
             state.searchedInspirations = state.inspirations
             
         case .writeInspirationButtonTapped:
@@ -50,10 +52,12 @@ final class InspirationNoteViewModel: ViewModelable {
             
         case .writeDailyButtonTapped:
             // TODO: navigate to DailyWritingView
+            coordinator.push(.dailyWriting(nil))
             break
             
         case .writeAppreciationButtonTapped:
             // TODO: navigate to AppreciationWritingView
+            coordinator.push(.appreciationWriting(nil))
             break
             
         case .search:
@@ -70,6 +74,10 @@ final class InspirationNoteViewModel: ViewModelable {
                 
                 return false
             }
+        case .dailyPreviewTapped(let id):
+            coordinator.push(.dailyReading(id))
+        case .appreciationPreviewTapped(let appreciation):
+            coordinator.push(.appreciationReading(appreciation))
         }
     }
     
@@ -84,7 +92,7 @@ final class InspirationNoteViewModel: ViewModelable {
         }
         
         let fetchAppreciationResult = SwiftDataManager.shared.fetchAllInspiration(InspirationType: Appreciation.self, context: context)
-        switch fetchDailyResult {
+        switch fetchAppreciationResult {
         case .success(let success):
             fetchedInspirations += success
         case .failure(let failure):

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/AppreciationPreviewContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/AppreciationPreviewContentView.swift
@@ -13,7 +13,7 @@ struct AppreciationPreviewContentView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(appreciation.title ?? "(제목 없음)")
-                .font(.title3)
+                .font(FFYFont.title3)
                 .foregroundStyle(FFYColor.black)
                 .lineLimit(1)
                 .padding(.bottom, 10)

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/DailyPreviewContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/DailyPreviewContentView.swift
@@ -13,7 +13,7 @@ struct DailyPreviewContentView: View {
     
     init(daily: Daily) {
         self.daily = daily
-        image = ImageManager.shared.loadImage(fromPath: daily.image ?? "")
+        image = ImageManager.shared.loadImage(withName: daily.image ?? "")
     }
     
     var body: some View {

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/DailyTextContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/DailyTextContentView.swift
@@ -14,7 +14,7 @@ struct DailyTextContentView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(daily.title ?? "(제목 없음)")
-                .font(.title3)
+                .font(FFYFont.title3)
                 .foregroundStyle(FFYColor.black)
                 .lineLimit(1)
                 .padding(.bottom, 10)

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationPreviewList.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationPreviewList.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct InspirationPreviewList: View {
     var inspirations: [any Inspiration]
+    var dailyPreviewTapAction: (String) -> Void
+    var appreciationPreviewTapAction: (Appreciation) -> Void
     
     var body: some View {
         ScrollView {
@@ -16,9 +18,18 @@ struct InspirationPreviewList: View {
                 ForEach(inspirations, id: \.id) { inspiration in
                     if let daily = inspiration as? Daily {
                         InspirationPreviewCard(inspiration: daily)
+                            .background(.white)
+                            .onTapGesture {
+                                dailyPreviewTapAction(daily.id)
+                            }
+                        
                     }
                     else if let appreciation = inspiration as? Appreciation {
                         InspirationPreviewCard(inspiration: appreciation)
+                            .background(.white)
+                            .onTapGesture {
+                                appreciationPreviewTapAction(appreciation)
+                            }
                     }
                     Rectangle()
                         .fill(FFYColor.gray1)

--- a/FunForYou/FunForYou/Sources/Utils/ImageManager.swift
+++ b/FunForYou/FunForYou/Sources/Utils/ImageManager.swift
@@ -34,7 +34,7 @@ final class ImageManager {
 
         do {
             try data.write(to: fileURL)
-            return fileURL.path
+            return name
         } catch {
             print("이미지 저장 실패:", error)
             return nil
@@ -46,13 +46,8 @@ final class ImageManager {
     /// - Parameter path: 저장된 이미지 파일의 전체 경로입니다.
     ///
     /// - Returns: 경로에 해당하는 `UIImage` 객체를 반환하며, 파일이 존재하지 않거나 읽기에 실패한 경우 `nil`을 반환합니다.
-    func loadImage(fromPath path: String) -> UIImage? {
-        let fileURL = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            print("파일이 존재하지 않음:", fileURL.path)
-            return nil
-        }
-
+    func loadImage(withName name: String) -> UIImage? {
+        let fileURL = getDocumentsDirectory().appendingPathComponent(name)
         return UIImage(contentsOfFile: fileURL.path)
     }
 


### PR DESCRIPTION
### Issue Number
close #82

### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

### 1. SwiftDataManager 모델 관련 이슈 해결

- Poem 객체를 특정 InspirationId로 필터링하여 가져오는 함수 fetchAllPoemFromInspirationId에서 FetchDescriptor 생성 시 predicate를 사용하는 방식에서 문제가 발생하여, 이를 우회하는 방식으로 수정했습니다.

🔧 주요 수정 사항
기존에는 #Predicate<Poem>을 활용해 FetchDescriptor(predicate:)에 전달했으나, 내부적으로 SwiftData의 조건 필터링이 정상적으로 동작하지 않아 런타임 오류가 발생했습니다.

해당 오류를 해결하기 위해 FetchDescriptor<Poem>()로 전체 데이터를 조회한 뒤, Swift의 .filter를 이용해 inspirationId 조건으로 수동 필터링하는 방식으로 수정하였습니다.

```Swift
// 기존 (오류 발생)
let predicate = #Predicate<Poem> { $0.type.id == inspirationId }
let fetchDescriptor = FetchDescriptor(predicate: predicate)

// 수정 (정상 동작)
let fetchDescriptor = FetchDescriptor<Poem>()
var poemList = try context.fetch(fetchDescriptor)
poemList = poemList.filter { $0.type.id == inspirationId }
```
✅ 결과
런타임 에러 없이 시상 ID에 해당하는 Poem 객체들을 정상적으로 불러올 수 있게 되었으며, 앱의 안정성과 데이터 필터링 신뢰도를 확보했습니다.

### 2. 일상 시상 저장된 이미지 경로 찾지 못하는 이슈 수정

이미지의 전체 저장 경로를 반환해 모델에 저장했었는데, /var/mobile/Containers/.../Documents/image.png 같은 경로 문자열을 저장해두면 앱을 재빌드시 getDocumentsDirectory()의 실제 경로가 바뀌므로 다음번 빌드에서 그 경로가 존재하지 않게 되는 이슈가 있었습니다.

-> 모델에는 이미지 이름 (UUID().uuidString) 만 저장하도록 하고, getDocumentDirectory() 를 이미지를 불러올 때 호출하여 경로를 설정해주도록 하였습니다.

### 3. 메인 탭 뷰 (시상 수첩, 나의 시집) 에서의 네비게이팅을 구현하였습니다.

### 시상 수첩
- 일상 시상 쓰기

https://github.com/user-attachments/assets/f3d683bd-5753-4e7b-9052-76aca8e4fa76

- 감상 시상 쓰기

https://github.com/user-attachments/assets/bac995ef-bb2f-48dc-80b6-460530dc8092

- 시상 자세히 보기

https://github.com/user-attachments/assets/3c0f342e-ee38-4a6c-9dd8-776c446965d8



### 나의 시집 - 끝맺은 시
- 시 쓰기

https://github.com/user-attachments/assets/8cefdf0a-fc34-4981-8d90-5ed8fc100320

- 쓰고 있는 시 이어쓰기

https://github.com/user-attachments/assets/ce86080f-d662-4261-93f6-000f43c235a3

- 시 조회

https://github.com/user-attachments/assets/eab257a6-0d09-41f6-93fa-e200ae1fd969






