### PR TITLE
✨ [feat] 일상 시상 편집 및 이미지 관련 기능 구현

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 /// 일상 읽기 뷰
 struct DailyReadingView: View {
     @StateObject var viewModel: DailyReadingViewModel
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) var context
     
     private let id: String
@@ -22,7 +21,21 @@ struct DailyReadingView: View {
     
     var body: some View {
         VStack {
-            DailyReadingNavigationBar(viewModel: viewModel)
+            DailyReadingTopView(
+                backButtonTapAction: {
+                    viewModel.action(.backButtonTapAction)
+                },
+                ellipseButtonTapAction: {
+                    viewModel.action(.ellipseButtonTapAction)
+                },
+                editButtonTapAction: {
+                    viewModel.action(.editButtonTapped)
+                },
+                deleteButtonTapAction: {
+                    viewModel.action(.deleteButtonTapped)
+                },
+                showModal: $viewModel.state.showModal
+            )
             
             ScrollView {
                 DailyReadingContentView(

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
@@ -41,7 +41,7 @@ struct DailyReadingView: View {
                 DailyReadingContentView(
                     title: viewModel.state.daily.title,
                     content: viewModel.state.daily.content,
-                    imagePath: viewModel.state.daily.image
+                    image: viewModel.state.image
                 )
                 
                 InspiredPoemCardsView(
@@ -60,6 +60,7 @@ struct DailyReadingView: View {
         }
         .onAppear {
             viewModel.action(.fetchDailyById(id, context))
+            viewModel.action(.fetchImage)
         }
         .overlay {
             if viewModel.state.isShowAlert {

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
@@ -14,6 +14,7 @@ final class DailyReadingViewModel: ViewModelable {
         var daily: Daily
         var inspiredPoems: [Poem] = []
         var isShowAlert: Bool = false
+        var showModal: Bool = false
     }
     
     enum Action {
@@ -23,6 +24,8 @@ final class DailyReadingViewModel: ViewModelable {
         case deleteDailyInspiration(String, ModelContext)
         case writeNewPoemButtonTapAction
         case readPoemButtonTapAction(Poem)
+        case ellipseButtonTapAction
+        case backButtonTapAction
     }
     
     @Published var state: State
@@ -39,60 +42,70 @@ final class DailyReadingViewModel: ViewModelable {
         switch action {
         case let .fetchDailyById(id, context):
             fetchDailyInspiration(id, context: context)
+            
         case .editButtonTapped:
             coordinator.push(.dailyWriting(id))
+            
         case .deleteButtonTapped:
             state.isShowAlert = true
+            
         case let .deleteDailyInspiration(id, context):
             deleteDailyInspiration(id, context: context)
+            
         case .writeNewPoemButtonTapAction:
             writeNewPoemButtonTapAction()
-            
+
         case .readPoemButtonTapAction(let poem):
             coordinator.push(.poemReading(poem))
-        }
-        
-        func fetchDailyInspiration(_ id: String, context: ModelContext) {
-            let result: Result<Daily?, Error> = SwiftDataManager.shared.fetchInspirationById(
-                inspirationType: Daily.self,
-                inspirationId: id,
-                context: context
-            )
             
-            switch result {
-            case .success(let daily):
-                if let daily = daily {
-                    state.daily = daily
-                } else {
-                    print("❗️ 해당 ID의 Daily를 찾을 수 없습니다.")
-                }
-            case .failure(let error):
-                print("❌ Daily fetch 실패: \(error.localizedDescription)")
-            }
-        }
-        
-        func deleteDailyInspiration(_ id: String, context: ModelContext) {
-            let result = SwiftDataManager.shared.deleteInspiration(inspiration: state.daily, context: context)
+        case .ellipseButtonTapAction:
+            state.showModal.toggle()
             
-            switch result {
-            case .success:
-                coordinator.popLast()
-            case .failure(let error):
-                print("❌ Daily 삭제 실패: \(error.localizedDescription)")
-            }
+        case .backButtonTapAction:
+            coordinator.popLast()
         }
+    }
+    
+    func fetchDailyInspiration(_ id: String, context: ModelContext) {
+        let result: Result<Daily?, Error> = SwiftDataManager.shared.fetchInspirationById(
+            inspirationType: Daily.self,
+            inspirationId: id,
+            context: context
+        )
         
-        func writeNewPoemButtonTapAction() {
-            coordinator.push(
-                .poemWriting(
-                    Poem(
-                        type: .appreciation(state.daily.id),
-                        title: "",
-                        content: ""
-                    )
+        switch result {
+        case .success(let daily):
+            if let daily = daily {
+                state.daily = daily
+            } else {
+                print("❗️ 해당 ID의 Daily를 찾을 수 없습니다.")
+            }
+        case .failure(let error):
+            print("❌ Daily fetch 실패: \(error.localizedDescription)")
+        }
+    }
+    
+    func deleteDailyInspiration(_ id: String, context: ModelContext) {
+        let result = SwiftDataManager.shared.deleteInspiration(inspiration: state.daily, context: context)
+        
+        switch result {
+        case .success:
+            coordinator.popLast()
+        case .failure(let error):
+            print("❌ Daily 삭제 실패: \(error.localizedDescription)")
+        }
+    }
+    
+    func writeNewPoemButtonTapAction() {
+        coordinator.push(
+            .poemWriting(
+                Poem(
+                    type: .appreciation(state.daily.id),
+                    title: "",
+                    content: ""
                 )
             )
-            
-        }
+        )
+        
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
@@ -15,6 +15,7 @@ final class DailyReadingViewModel: ViewModelable {
         var inspiredPoems: [Poem] = []
         var isShowAlert: Bool = false
         var showModal: Bool = false
+        var image: UIImage? = nil
     }
     
     enum Action {
@@ -26,6 +27,7 @@ final class DailyReadingViewModel: ViewModelable {
         case readPoemButtonTapAction(Poem)
         case ellipseButtonTapAction
         case backButtonTapAction
+        case fetchImage
     }
     
     @Published var state: State
@@ -63,6 +65,10 @@ final class DailyReadingViewModel: ViewModelable {
             
         case .backButtonTapAction:
             coordinator.popLast()
+        case .fetchImage:
+            if let imagePath = state.daily.image {
+                state.image = ImageManager.shared.loadImage(withName: imagePath)
+            }
         }
     }
     
@@ -78,10 +84,10 @@ final class DailyReadingViewModel: ViewModelable {
             if let daily = daily {
                 state.daily = daily
             } else {
-                print("❗️ 해당 ID의 Daily를 찾을 수 없습니다.")
+                print("해당 ID의 Daily를 찾을 수 없습니다.")
             }
         case .failure(let error):
-            print("❌ Daily fetch 실패: \(error.localizedDescription)")
+            print("Daily fetch 실패: \(error.localizedDescription)")
         }
     }
     
@@ -92,7 +98,7 @@ final class DailyReadingViewModel: ViewModelable {
         case .success:
             coordinator.popLast()
         case .failure(let error):
-            print("❌ Daily 삭제 실패: \(error.localizedDescription)")
+            print("Daily 삭제 실패: \(error.localizedDescription)")
         }
     }
     

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingContentView.swift
@@ -12,17 +12,16 @@ struct DailyReadingContentView: View {
     var title: String?
     /// 시상 내용
     var content: String?
-    /// 시상 이미지 경로
-    var imagePath: String?
+    /// 시상 이미지
+    var image: UIImage?
     
     var body: some View {
-        VStack (alignment: .leading) {
+        VStack {
             TitleSceneView(title: self.title)
             
-            ImageSceneView(imagePath: self.imagePath)
+            ImageSceneView(image: self.image)
             
             ContentSceneView(content: self.content)
-            
         }
         .padding(.horizontal, 24)
     }
@@ -32,6 +31,6 @@ struct DailyReadingContentView: View {
     DailyReadingContentView(
         title: Daily.mockData.title,
         content: Daily.mockData.content,
-        imagePath: "/path" // 예시 path 입니다.
+        image: UIImage(named: "PoemPaperSet")
     )
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
@@ -6,32 +6,22 @@
 //
 import SwiftUI
 
+/// 일상 읽기 네비게이션 바
 struct DailyReadingNavigationBar: View {
-    @Environment(\.dismiss) private var dismiss
-    @ObservedObject var viewModel: DailyReadingViewModel
+    var backButtonTapAction: () -> Void
+    var ellipseButtonTapAction: () -> Void
     
     var body: some View {
         ZStack(alignment: .trailing) {
             NavigationBar(
                 title: "일상 읽기",
-                style: .backTitle,
-                onBack: {
-                    dismiss()
-                }
-            )
+                style: .backTitle
+            ) {
+                backButtonTapAction()
+            }
             
-            Menu {
-                Button {
-                    viewModel.action(.editButtonTapped)
-                } label: {
-                    Text("고쳐 쓰기")
-                }
-                
-                Button(role: .destructive) {
-                    viewModel.action(.deleteButtonTapped)
-                } label: {
-                    Text("지우기")
-                }
+            Button {
+                ellipseButtonTapAction()
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.title3)
@@ -39,8 +29,10 @@ struct DailyReadingNavigationBar: View {
                     .padding(.bottom)
                     .padding(.trailing, 24)
             }
-
         }
-
     }
+}
+
+#Preview {
+    DailyReadingNavigationBar(backButtonTapAction: {}, ellipseButtonTapAction: {})
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingTopView.swift
@@ -1,0 +1,61 @@
+//
+//  DailyReadingTopView.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/8/25.
+//
+import SwiftUI
+
+/// 일상 읽기 네비게이션 바 + 커스텀 메뉴(모달)
+struct DailyReadingTopView: View {
+    var backButtonTapAction: () -> Void
+    var ellipseButtonTapAction: () -> Void
+    var editButtonTapAction: () -> Void
+    var deleteButtonTapAction: () -> Void
+    @Binding var showModal: Bool
+    
+    init(
+        backButtonTapAction: @escaping () -> Void,
+        ellipseButtonTapAction: @escaping () -> Void,
+        editButtonTapAction: @escaping () -> Void,
+        deleteButtonTapAction: @escaping () -> Void,
+        showModal: Binding<Bool>
+    ) {
+        self.backButtonTapAction = backButtonTapAction
+        self.ellipseButtonTapAction = ellipseButtonTapAction
+        self.editButtonTapAction = editButtonTapAction
+        self.deleteButtonTapAction = deleteButtonTapAction
+        self._showModal = showModal
+    }
+    
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            // 네비게이션 바
+            DailyReadingNavigationBar(
+                backButtonTapAction: backButtonTapAction,
+                ellipseButtonTapAction: ellipseButtonTapAction
+            )
+            
+            // 메뉴 모달
+            TopMenuModal(
+                showModal: $showModal,
+                modalStyle: .defaultTop(
+                    modify: {
+                        editButtonTapAction()
+                    },
+                    delete: {
+                        deleteButtonTapAction()
+                    }
+                )
+            )
+            .padding(.horizontal, 20)
+        }
+        .frame(height: 35, alignment: .top)
+        .zIndex(100)
+    }
+
+}
+
+#Preview {
+    DailyReadingTopView(backButtonTapAction: {}, ellipseButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {}, showModal: .constant(true))
+}

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ImageSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/ImageSceneView.swift
@@ -9,31 +9,27 @@ import SwiftUI
 /// 일상 시상 이미지 서브뷰
 struct ImageSceneView: View {
     /// 시상 이미지 경로
-    var imagePath: String?
+    var image: UIImage?
     var isPadding: Bool {
-        imagePath != nil
+        image != nil
     }
     
     var body: some View {
         VStack {
-            if let imagePath {
-                // TODO: - ImageManager이용해서 loadImage 구현 (Berry)
-                Image("PoemPaperSet")
+            if let image = image {
+                Image(uiImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: .infinity)
                     .frame(height: 240)
                     .clipped()
                     .cornerRadius(20)
-                    .padding(.horizontal, 24)
                     .allowsHitTesting(false)
             }
         }
         .padding(.bottom, isPadding ? 20 : 0)
+        
     }
 }
 
 #Preview {
-    // 예시 path 입니다.
-    ImageSceneView(imagePath: "/path")
+    ImageSceneView(image: UIImage(named: "PoemPaperSet"))
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/TitleSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/TitleSceneView.swift
@@ -14,7 +14,7 @@ struct TitleSceneView: View {
     var body: some View {
         VStack {
             if let title {
-                Text("\(title)")
+                Text("\(title.forceCharWrapping)")
                     .font(FFYFont.title1)
                     .foregroundStyle(FFYColor.black)
                     .lineLimit(2)

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyWriting/DailyWritingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyWriting/DailyWritingView.swift
@@ -43,6 +43,11 @@ struct DailyWritingView: View {
         .sheet(isPresented: $viewModel.state.isShowImagePicker) {
             PhotoPicker(selectedImage: $viewModel.state.selectedImage)
         }
+        .onAppear {
+            if let id = viewModel.id {
+                viewModel.action(.fetchDailyById(id, context))
+            }
+        }
         .overlay {
             if viewModel.state.isShowAlert {
                 PrimaryAlert(

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyWriting/SubViews/PhotoButtonView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyWriting/SubViews/PhotoButtonView.swift
@@ -49,8 +49,6 @@ struct PhotoButtonView: View {
         if let image = selectedImage {
             Image(uiImage: image)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(maxWidth: .infinity)
                 .frame(height: 240)
                 .clipped()
                 .cornerRadius(20)

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/subView/InspirationReadingSheet.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/subView/InspirationReadingSheet.swift
@@ -15,11 +15,12 @@ struct InspirationReadingSheet: View {
         NavigationStack {
             ScrollView {
                 Group {
-                    if let daily = inspiration as? Daily {
+                    if let daily = inspiration as? Daily, let imagePath = daily.image {
+                        let image = ImageManager.shared.loadImage(withName: imagePath)
                         DailyReadingContentView(
                             title: daily.title,
                             content: daily.content,
-                            imagePath: daily.image
+                            image: image
                         )
                     } else if let appreciation = inspiration as? Appreciation {
                         AppreciationContentView(


### PR DESCRIPTION
### 🖥️ 작업 내역

close #58 

> 구현 내용 및 작업 했던 내역을 적어주세요.
- 일상 시상 화면에 메뉴 커스텀 적용
- '고쳐쓰기' 클릭해 일상 시상 편집 뷰로 이동시 기존 내용 표시
- 변경된 내용 업데이트
- 이미지 경로 이용해 이미지 표시하기


https://github.com/user-attachments/assets/cfa63057-31e0-4869-a1d6-8f8d4be45497