### PR TITLE
💄 [style] 우측상단 버튼 UI 강조

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionListView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionListView.swift
@@ -36,6 +36,7 @@ struct CompleteCollectionListView: View {
                     .padding(.bottom, 32)
                 }
             }
+            .padding(.horizontal, 20)
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/SubView/CompleteCollectionTopView.swift
@@ -15,7 +15,7 @@ struct CompleteCollectionTopView: View {
     }
     
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(alignment: .bottom, spacing: 0) {
             Text("끝맺은 시")
                 .font(FFYFont.largeTitle)
                 .foregroundStyle(.black)
@@ -25,6 +25,7 @@ struct CompleteCollectionTopView: View {
             }) {
                 Text("시 쓰기")
                     .foregroundStyle(FFYColor.pinkDark)
+                    .font(FFYFont.title3)
             }
             .buttonStyle(.plain)
         }

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationNoteTopContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationNoteTopContentView.swift
@@ -15,7 +15,7 @@ struct InspirationNoteTopContentView: View {
     }
     
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(alignment: .bottom, spacing: 0) {
             Text("시상 수첩")
                 .font(FFYFont.largeTitle)
                 .foregroundStyle(.black)
@@ -25,6 +25,7 @@ struct InspirationNoteTopContentView: View {
             }) {
                 Text("시상 쓰기")
                     .foregroundStyle(FFYColor.pinkDark)
+                    .font(FFYFont.title3)
             }
             .buttonStyle(.plain)
         }


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

#### 1. 시상수첩, 나의 시집 탭바 두 화면의 우측 상단 버튼을 더 식별할 수 있게 title3 스타일을 적용시켰습니다.(비포 & 애프터)
<img width="300" alt="스크린샷 2025-06-09 오후 5 43 54" src="https://github.com/user-attachments/assets/593673ad-06f4-4824-9630-890e3cf44655" />
<img width="300" alt="스크린샷 2025-06-09 오후 5 44 02" src="https://github.com/user-attachments/assets/89fd1008-a597-48a3-ba7b-61d7d364f2e7" />


#### 2. 끝맺은 시 리스트 중앙 여백을 줄이기 위해 디자인대로 좌우 패딩을 추가했습니다
<img width="300" alt="Simulator Screenshot - iPhone 16" src="https://github.com/user-attachments/assets/a24ab340-26c2-47bb-aaa9-993645c0ed52" />