### PR TITLE
💄 [style] 감상읽기 텍스트 정렬 수정

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationContentView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationContentView.swift
@@ -32,8 +32,10 @@ struct AppreciationContentView: View {
             if let content {
                 Text(content)
                     .font(FFYFont.body)
+                    .foregroundStyle(FFYColor.black)
                     .lineSpacing(5)
-                    .frame(maxWidth: .infinity)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/MemorableSceneView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/MemorableSceneView.swift
@@ -22,6 +22,8 @@ struct MemorableSceneView: View {
                 Text(scene)
                     .font(FFYFont.body)
                     .foregroundStyle(FFYColor.black)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/QuoteMarkView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/QuoteMarkView.swift
@@ -20,6 +20,9 @@ struct QuoteMarkView: View {
             if let title {
                 Text(title)
                     .font(FFYFont.title3)
+                    .foregroundStyle(FFYColor.black)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
             }
             
             Image("double-quotes-r")


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

기억에 남는 장면, 마음의 한 줄, 내 감상 내용 3종 텍스트뷰의 정렬에 디자인 사항을 반영했습니다.
시쓰기 화면에서 sheet로 올라오는 곳에서도 확인했습니다

<img width="250" alt="Simulator Screenshot - iPhone 16 - 2025-06-10 at 17 15 42" src="https://github.com/user-attachments/assets/e7c4f209-f91d-4123-9027-8b8503958ccb" /><img width="250" alt="Simulator Screenshot - iPhone 16 - 2025-06-10 at 17 15 58" src="https://github.com/user-attachments/assets/230427d6-1ff3-4d25-9d38-1a539712f3a6" />