### PR TITLE
🐛 [fix] 작성중인 시 클릭시 바로 편집 뷰로 전환되도록 수정

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
@@ -28,7 +28,7 @@ final class OngoingCollectionViewModel: ViewModelable {
         case backButtonTapAction
         /// 검색하기
         case search
-        /// 시 버튼 눌렀을 때 쓰는중인 시 화면으로 넘어가기
+        /// 시 버튼 눌렀을 때 쓰는중인 시 화면(편집)으로 넘어가기
         case ongoingPoemTapped(Poem)
 
     }
@@ -52,7 +52,7 @@ final class OngoingCollectionViewModel: ViewModelable {
             state.searchedPoems = searchPoems(searchText: state.searchText)
 
         case .ongoingPoemTapped(let poem):
-            coordinator.push(.poemReading(poem))
+            coordinator.push(.poemWriting(poem))
         }
     }
 

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingView.swift
@@ -70,7 +70,7 @@ struct PoemWritingView: View {
                         isShowingAlert = false
                     },
                     onSecondary: {
-                        dismiss()
+                        viewModel.action(.deletePoem(context: context))
                     },
                     isVisible: $isShowingAlert
                 )

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingViewModel.swift
@@ -49,7 +49,7 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
         case onAppeared(context: ModelContext)
         case updateCanSave
         case saveOrUpdatePoem(context: ModelContext, isCompleted: Bool)
-
+        case deletePoem(context: ModelContext)
     }
 
     func action(_ action: Action) {
@@ -100,9 +100,12 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
                     error.localizedDescription
                 )
             }
+            
         case .updateCanSave:
             canSave = Self.updateCanSave(poem: state.poem)
-
+            
+        case .deletePoem(let context):
+            deletePoemById(context: context)
         }
 
     }
@@ -185,6 +188,19 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
         }
     }
 
+    private func deletePoemById(context: ModelContext) {
+        let result = SwiftDataManager.shared.deletePoem(poem: state.poem, context: context)
+        
+        switch result {
+        case .success:
+            print("삭제 성공")
+            coordinator.popLast()
+        
+        case .failure(let error):
+            print("시 삭제 실패: ",error.localizedDescription)
+        }
+    }
+    
     private static func updateCanSave(poem: Poem) -> Bool {
         let titleNotEmpty = !poem.title.trimmingCharacters(
             in: .whitespacesAndNewlines


### PR DESCRIPTION
### 🖥️ 작업 내역

close #106 

> 구현 내용 및 작업 했던 내역을 적어주세요.

작성중인 시에서 특정 시를 클릭하면 바로 시 쓰기 편집 화면으로 이동합니다.
따로 삭제 버튼이 존재하지 않는 형태라, 임시저장이나 시 끝맺기를 하지 않고 뒤로가기를 클릭하면 경고 이후 삭제되도록 구현해두었습니다.

https://github.com/user-attachments/assets/b149f66a-830e-44c4-b38c-cd0b850f5971

