### PR TITLE
♻️ [refactor] 커스텀 메뉴 시스템 메뉴로 수정

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
@@ -74,10 +74,6 @@ struct AppreciationReadingView: View {
                 )
             }
         }
-        .onTapGesture {
-            // 메뉴 외의 다른 영역 터치할 때 메뉴 없어지도록
-            viewModel.action(.menuDisappearAction)
-        }
         .onAppear {
             // 시상으로 지은 시 불러오기
             viewModel.action(.fetchCompletedPoemsFromInspirationID(context))

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingView.swift
@@ -23,20 +23,14 @@ struct AppreciationReadingView: View {
     var body: some View {
         VStack(spacing: 0) {
             // 네비게이션 바 영역
-            AppreciationReadingTopView(
+            AppreciationReadingNavigationBar(
                 backButtonTapAction: {
                     viewModel.action(.backButtonTapAction)
-                },
-                ellipseButtonTapAction: {
-                    viewModel.action(.ellipseButtonTapAction)
-                },
-                editButtonTapAction: {
+                }, editButtonTapAction: {
                     viewModel.action(.editButtonTapAction)
-                },
-                deleteButtonTapAction: {
+                }, deleteButtonTapAction: {
                     viewModel.action(.deleteButtonTapAction)
-                },
-                showModal: $viewModel.state.showModal
+                }
             )
             
             ScrollView {

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/AppreciationReadingViewModel.swift
@@ -18,9 +18,6 @@ final class AppreciationReadingViewModel: ViewModelable {
         /// 이 시상으로 지은 시 배열
         var inspiredPoems: [Poem] = []
         
-        /// 네비게이션 메뉴 보여주기 결정
-        var showModal: Bool = false
-        
         /// 감상 지우기 alert 띄우기 결정
         var showAlert: Bool = false
     }
@@ -28,10 +25,6 @@ final class AppreciationReadingViewModel: ViewModelable {
     enum Action {
         /// 이전 버튼 눌러서 화면 빠져나가기
         case backButtonTapAction
-        /// 상단 메뉴 띄우기
-        case ellipseButtonTapAction
-        /// 메뉴 없어지게 하기
-        case menuDisappearAction
         /// 감상 편집 화면으로 연결
         case editButtonTapAction
         /// 감상 지우기 alert 띄우기
@@ -58,18 +51,11 @@ final class AppreciationReadingViewModel: ViewModelable {
         case .backButtonTapAction:
             coordinator.popLast()
             
-        case .ellipseButtonTapAction:
-            state.showModal.toggle()
-            
-        case .menuDisappearAction:
-            state.showModal = false
-            
         case .editButtonTapAction:
             print("시상 수정하기 화면으로 연결")
             coordinator.push(.appreciationWriting(state.appreciation))
             
         case .deleteButtonTapAction:
-            state.showModal.toggle()
             state.showAlert.toggle()
             
         case .deleteAppreciation(let context):

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
@@ -47,7 +47,7 @@ struct AppreciationReadingNavigationBar: View {
                     .padding(.bottom)
                     .padding(.trailing, 24)
             }
-
+            .contentShape(Circle())
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingNavigationBar.swift
@@ -13,9 +13,11 @@ struct AppreciationReadingNavigationBar: View {
     // MARK: - Properties
     /// 화면 dismiss시키기
     var backButtonTapAction: () -> Void
+    /// 고쳐쓰기 버튼 눌렀을 때: 감상 페이지로 이동
+    var editButtonTapAction: () -> Void
+    /// 지우기 버튼 눌렀을 때: 삭제 alert 띄우기
+    var deleteButtonTapAction: () -> Void
     
-    /// ellipse 버튼 눌릴 때 액션(모달 띄우는 bool 변경시키기)
-    var ellipseButtonTapAction: () -> Void
         
     // MARK: - View
     var body: some View {
@@ -24,9 +26,20 @@ struct AppreciationReadingNavigationBar: View {
                 backButtonTapAction()
             }
             
-            Button {
-                // 모달 띄우기
-                ellipseButtonTapAction()
+            Menu {
+                // 고쳐 쓰기
+                Button {
+                    editButtonTapAction()
+                } label: {
+                    Text("고쳐 쓰기")
+                }
+                
+                // 지우기
+                Button(role: .destructive) {
+                    deleteButtonTapAction()
+                } label: {
+                    Text("지우기")
+                }
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.title3)
@@ -40,5 +53,5 @@ struct AppreciationReadingNavigationBar: View {
 }
 
 #Preview {
-    AppreciationReadingNavigationBar(backButtonTapAction: {}, ellipseButtonTapAction: {})
+    AppreciationReadingNavigationBar(backButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {})
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Appreciation/AppreciationReading/SubView/AppreciationReadingTopView.swift
@@ -35,10 +35,10 @@ struct AppreciationReadingTopView: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
             // 네비게이션 바
-            AppreciationReadingNavigationBar(
-                backButtonTapAction: backButtonTapAction,
-                ellipseButtonTapAction: ellipseButtonTapAction
-            )
+//            AppreciationReadingNavigationBar(
+//                backButtonTapAction: backButtonTapAction,
+//                ellipseButtonTapAction: ellipseButtonTapAction
+//            )
             
             // 메뉴 모달
             TopMenuModal(

--- a/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/CompleteCollection/CompleteCollectionViewModel.swift
@@ -44,7 +44,7 @@ final class CompleteCollectionViewModel: ViewModelable {
             state.searchedPoems = searchPoems(searchText: state.searchText)
             
         case .continueWriteButtonTapped:
-            // TODO: navigate to ongoing poem list view
+            // navigate to ongoing poem list view
             coordinator.push(.ongoingCollection)
             break
         case .completePoemTapped(let poem):

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingView.swift
@@ -21,20 +21,14 @@ struct DailyReadingView: View {
     
     var body: some View {
         VStack {
-            DailyReadingTopView(
+            DailyReadingNavigationBar(
                 backButtonTapAction: {
                     viewModel.action(.backButtonTapAction)
-                },
-                ellipseButtonTapAction: {
-                    viewModel.action(.ellipseButtonTapAction)
-                },
-                editButtonTapAction: {
+                }, editButtonTapAction: {
                     viewModel.action(.editButtonTapped)
-                },
-                deleteButtonTapAction: {
+                }, deleteButtonTapAction: {
                     viewModel.action(.deleteButtonTapped)
-                },
-                showModal: $viewModel.state.showModal
+                }
             )
             
             ScrollView {

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/DailyReadingViewModel.swift
@@ -14,7 +14,6 @@ final class DailyReadingViewModel: ViewModelable {
         var daily: Daily
         var inspiredPoems: [Poem] = []
         var isShowAlert: Bool = false
-        var showModal: Bool = false
         var image: UIImage? = nil
     }
     
@@ -26,7 +25,6 @@ final class DailyReadingViewModel: ViewModelable {
         case writeNewPoemButtonTapAction
         case fetchAllPoemFromInspirationId(ModelContext)
         case readPoemButtonTapAction(Poem)
-        case ellipseButtonTapAction
         case backButtonTapAction
         case fetchImage
     }
@@ -63,9 +61,6 @@ final class DailyReadingViewModel: ViewModelable {
 
         case .readPoemButtonTapAction(let poem):
             coordinator.push(.poemReading(poem))
-            
-        case .ellipseButtonTapAction:
-            state.showModal.toggle()
             
         case .backButtonTapAction:
             coordinator.popLast()

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
@@ -8,9 +8,12 @@ import SwiftUI
 
 /// 일상 읽기 네비게이션 바
 struct DailyReadingNavigationBar: View {
+    // MARK: - Properties
     var backButtonTapAction: () -> Void
-    var ellipseButtonTapAction: () -> Void
+    var editButtonTapAction: () -> Void
+    var deleteButtonTapAction: () -> Void
     
+    // MARK: - View
     var body: some View {
         ZStack(alignment: .trailing) {
             NavigationBar(
@@ -20,19 +23,33 @@ struct DailyReadingNavigationBar: View {
                 backButtonTapAction()
             }
             
-            Button {
-                ellipseButtonTapAction()
+            Menu {
+                // 고쳐 쓰기
+                Button {
+                    // 일상 편집 페이지로 이동
+                    editButtonTapAction()
+                } label: {
+                    Text("고쳐 쓰기")
+                }
+                
+                // 지우기
+                Button(role: .destructive) {
+                    // 정말 지우겠냐는 alert 띄우기
+                    deleteButtonTapAction()
+                } label: {
+                    Text("지우기")
+                }
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.title3)
                     .foregroundStyle(FFYColor.pinkDark)
                     .padding(.bottom)
                     .padding(.trailing, 24)
-            }
+            }            
         }
     }
 }
 
 #Preview {
-    DailyReadingNavigationBar(backButtonTapAction: {}, ellipseButtonTapAction: {})
+    DailyReadingNavigationBar(backButtonTapAction: {}, editButtonTapAction: {}, deleteButtonTapAction: {})
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingNavigationBar.swift
@@ -45,7 +45,8 @@ struct DailyReadingNavigationBar: View {
                     .foregroundStyle(FFYColor.pinkDark)
                     .padding(.bottom)
                     .padding(.trailing, 24)
-            }            
+            }
+            .contentShape(Circle())
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Daily/DailyReading/SubViews/DailyReadingTopView.swift
@@ -31,10 +31,10 @@ struct DailyReadingTopView: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
             // 네비게이션 바
-            DailyReadingNavigationBar(
-                backButtonTapAction: backButtonTapAction,
-                ellipseButtonTapAction: ellipseButtonTapAction
-            )
+//            DailyReadingNavigationBar(
+//                backButtonTapAction: backButtonTapAction,
+//                ellipseButtonTapAction: ellipseButtonTapAction
+//            )
             
             // 메뉴 모달
             TopMenuModal(

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
@@ -18,18 +18,15 @@ struct InspirationNoteView: View {
     var body: some View {
         VStack(spacing: 0) {
             InspirationNoteTopView(
-                writeInspirationButtonTapAction: {
-                    viewModel.action(.writeInspirationButtonTapped)
-                },
                 writeDailyButtonTapAction: {
                     viewModel.action(.writeDailyButtonTapped)
                 },
                 writeAppreciationButtonTapAction: {
                     viewModel.action(.writeAppreciationButtonTapped)
-                },
-                showWriteModal: $viewModel.state.showWriteModal
+                }                  
             )
-            .padding(.top, 20)
+            .padding(.vertical, 20)
+            .padding(.horizontal, 24)
             
             QuestionCarouselView(questions: $viewModel.state.questions, selectedQuestionIdx: $viewModel.state.selectedQuestionIdx)
                 .padding(.bottom, 20)
@@ -38,6 +35,7 @@ struct InspirationNoteView: View {
                 .onChange(of: viewModel.state.searchText) {
                     viewModel.action(.search)
                 }
+                .padding(.bottom, 8)
             
             InspirationPreviewList(
                 inspirations: viewModel.state.searchedInspirations,

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteView.swift
@@ -50,9 +50,6 @@ struct InspirationNoteView: View {
         .onAppear {
             viewModel.action(.viewAppeared(context))
         }
-        .onDisappear {
-            viewModel.action(.viewDisappeared)
-        }
         .hideKeyboardOnTap()
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/InspirationNoteViewModel.swift
@@ -17,13 +17,10 @@ final class InspirationNoteViewModel: ViewModelable {
         var questions: [String] = []
         var selectedQuestionIdx: Int = 0
         var searchText: String = ""
-        var showWriteModal: Bool = false
     }
     
     enum Action {
         case viewAppeared(ModelContext)
-        case viewDisappeared
-        case writeInspirationButtonTapped
         case writeDailyButtonTapped
         case writeAppreciationButtonTapped
         case dailyPreviewTapped(String)
@@ -42,23 +39,17 @@ final class InspirationNoteViewModel: ViewModelable {
     func action(_ action: Action) {
         switch action {
         case .viewAppeared(let context):
-            // TODO: 뷰 보여질 때 SwiftDataManager로부터 inspiration 가져오기
+            // 뷰 보여질 때 SwiftDataManager로부터 inspiration 가져오기
             state.inspirations = fetchInspirations(context: context)
             state.searchedInspirations = state.inspirations
             
-        case .viewDisappeared:
-            state.showWriteModal = false
-            
-        case .writeInspirationButtonTapped:
-            state.showWriteModal.toggle()
-            
         case .writeDailyButtonTapped:
-            // TODO: navigate to DailyWritingView
+            // navigate to DailyWritingView
             coordinator.push(.dailyWriting(nil))
             break
             
         case .writeAppreciationButtonTapped:
-            // TODO: navigate to AppreciationWritingView
+            // navigate to AppreciationWritingView
             coordinator.push(.appreciationWriting(nil))
             break
             

--- a/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationNoteTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/InspirationNote/SubView/InspirationNoteTopView.swift
@@ -7,44 +7,39 @@
 import SwiftUI
 
 struct InspirationNoteTopView: View {
-    var writeInspirationButtonTapAction: () -> Void
     var writeDailyButtonTapAction: () -> Void
     var writeAppreciationButtonTapAction: () -> Void
-    @Binding var showWriteModal: Bool
-    
-    init(
-        writeInspirationButtonTapAction: @escaping () -> Void,
-        writeDailyButtonTapAction: @escaping () -> Void,
-        writeAppreciationButtonTapAction: @escaping () -> Void,
-        showWriteModal: Binding<Bool>
-    ) {
-        self.writeInspirationButtonTapAction = writeInspirationButtonTapAction
-        self.writeDailyButtonTapAction = writeDailyButtonTapAction
-        self.writeAppreciationButtonTapAction = writeAppreciationButtonTapAction
-        self._showWriteModal = showWriteModal
-    }
     
     var body: some View {
-        VStack(alignment: .trailing, spacing: 0) {
-            InspirationNoteTopContentView(
-                writeInspirationButtonTapAction: writeInspirationButtonTapAction
-            )
+        HStack(alignment: .bottom, spacing: 0) {
+            // 뷰 제목
+            Text("시상 수첩")
+                .font(FFYFont.largeTitle)
+                .foregroundStyle(FFYColor.black)
             
-            TopMenuModal(
-                showModal: $showWriteModal,
-                modalStyle: .inspirationTop(
-                    daily: {
-                        writeDailyButtonTapAction()
-                    },
-                    appreciation: {
-                        writeAppreciationButtonTapAction()
-                    }
-                )
-            )
+            Spacer()
+            
+            // 메뉴 버튼
+            Menu {
+                // 일상 이야기예요
+                Button {
+                    writeDailyButtonTapAction()
+                } label: {
+                    Text("일상 이야기예요")
+                }
+                
+                // 감상한 콘텐츠가 있어요
+                Button {
+                    writeAppreciationButtonTapAction()
+                } label: {
+                    Text("감상한 콘텐츠가 있어요")
+                }
+            } label: {
+                Text("시상 쓰기")
+                    .foregroundStyle(FFYColor.pinkDark)
+                    .font(FFYFont.title3)
+            }
         }
-        .frame(height: 58, alignment: .top)
-        .padding(.horizontal, 24)
-        .zIndex(100)
     }
 }
 

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingView.swift
@@ -24,28 +24,21 @@ struct PoemReadingView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-                PoemReadingTopView(
-                    poem: viewModel.state.poem,
-                    ellipseButtonTapAction: {
-                        viewModel.action(.ellipseButtonTapAction)
-                    },
+                PoemReadingNavigationBar(
+                    isPoemCompleted: viewModel.state.poem.isCompleted,
                     editButtonTapAction: {
                         viewModel.action(.editButtonTapAction)
                     },
                     deleteButtonTapAction: {
-                        viewModel.state.showModal = false
-                        showDeleteAlert = true
-                        //                        viewModel.action(
-                        //                            .deleteButtonTapAction(context: context)
-                        //                        )
+                        viewModel.action(.deleteButtonTapAction)
                     },
                     backButtonTapAction: {
                         viewModel.action(.backButtonTapAction)
-                    },
-                    showModal: $viewModel.state.showModal
+                    }
                 )
+                
 
-                // TODO: 시 제목, 내용을 볼 수 있게 한다.
+                // 시 제목, 내용을 볼 수 있게 한다.
                 PoemReadingScrollView(
                     viewModel: viewModel
                 )
@@ -60,21 +53,18 @@ struct PoemReadingView: View {
             }
 
             // 커스텀 얼럿 뷰
-            if showDeleteAlert {
+            if viewModel.state.showDeleteAlert {
                 PrimaryAlert(
                     style: .deletePoem,
                     onPrimary: {
-                        showDeleteAlert = false
+                        withAnimation {
+                            viewModel.state.showDeleteAlert = false
+                        }
                     },
                     onSecondary: {
-                        showDeleteAlert = false
-                        viewModel.action(
-
-                            .deleteButtonTapAction(context: context)
-                        )
-
+                        viewModel.action(.deletePoem(context: context))
                     },
-                    isVisible: $showDeleteAlert
+                    isVisible: $viewModel.state.showDeleteAlert
                 )
             }
         }

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
@@ -48,6 +48,7 @@ struct PoemReadingNavigationBar: View {
                     .padding(.bottom)
                     .padding(.trailing, 24)
             }
+            .contentShape(Circle())
         }
     }
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingNavigationBar.swift
@@ -8,24 +8,39 @@
 import SwiftUI
 
 /// 시  읽기 페이지의 네비게이션 바
-/// - 우측 ellipse 버튼 누르면 고쳐 쓰기, 지우기 메뉴 띄우고 기능 연결(예정)
+/// - 우측 ellipse 버튼 누르면 고쳐 쓰기, 지우기 메뉴 띄움
 struct PoemReadingNavigationBar: View {
     // MARK: - Properties
-    var poem: Poem
-    /// ellipse 버튼 눌릴 때 액션(모달 띄우는 bool 변경시키기)
-    var ellipseButtonTapAction: () -> Void
+    var isPoemCompleted: Bool
+    var editButtonTapAction: () -> Void
+    var deleteButtonTapAction: () -> Void
     var backButtonTapAction: () -> Void
 
     // MARK: - View
     var body: some View {
         ZStack(alignment: .trailing) {
-            NavigationBar( title: poem.isCompleted ? "시 낭독하기" : "쓰고 있는 시", style: .backTitle) {
-                backButtonTapAction()
-            }
+            NavigationBar(
+                title: isPoemCompleted ? "시 낭독하기" : "쓰고 있는 시",
+                style: .backTitle,
+                onBack: {
+                    backButtonTapAction()
+                }
+            )
 
-            Button {
-                // 모달 띄우기
-                ellipseButtonTapAction()
+            Menu {
+                // 고쳐 쓰기
+                Button {
+                    editButtonTapAction()
+                } label: {
+                    Text("고쳐 쓰기")
+                }
+                
+                // 지우기
+                Button(role: .destructive) {
+                    deleteButtonTapAction()
+                } label: {
+                    Text("지우기")
+                }
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.title3)
@@ -33,15 +48,15 @@ struct PoemReadingNavigationBar: View {
                     .padding(.bottom)
                     .padding(.trailing, 24)
             }
-
         }
     }
 }
 
 #Preview {
     PoemReadingNavigationBar(
-        poem: samplePoem, 
-        ellipseButtonTapAction: {},
+        isPoemCompleted: samplePoem.isCompleted,
+        editButtonTapAction: {},
+        deleteButtonTapAction: {},
         backButtonTapAction: {}
     )
 }

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingTopView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/subViews/PoemReadingTopView.swift
@@ -40,11 +40,11 @@ struct PoemReadingTopView: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
             // 네비게이션 바
-            PoemReadingNavigationBar(
-                poem: poem,
-                ellipseButtonTapAction: ellipseButtonTapAction,
-                backButtonTapAction: backButtonTapAction
-            )
+//            PoemReadingNavigationBar(
+//                poem: poem,
+//                ellipseButtonTapAction: ellipseButtonTapAction,
+//                backButtonTapAction: backButtonTapAction
+//            )
 
             // 메뉴 모달
             TopMenuModal(


### PR DESCRIPTION
### 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.

#### 시상수첩, 일상 읽기, 감상 읽기, 끝맺은 시 읽기 화면의 메뉴를 커스텀 모달에서 시스템 기본 Menu 컴포넌트로 교체

- 기존에 연결되어 있던 액션은 동일하게 유지했습니다.
- 사용하지 않게 된 커스텀 메뉴 관련 변수는 삭제했습니다.

시상수첩
<img width="200" alt="스크린샷 2025-06-11 오후 7 58 13" src="https://github.com/user-attachments/assets/a79ffec9-d3a0-4e6d-a612-3a7bcc5f8a78" />

일상 읽기
<img width="200" alt="스크린샷 2025-06-11 오후 7 58 13" src="https://github.com/user-attachments/assets/299bfbf1-336f-4ef6-b645-7e3167044852" />

감상 읽기
<img width="200" alt="스크린샷 2025-06-11 오후 7 58 13" src="https://github.com/user-attachments/assets/51ea13c6-8f2d-4bc1-8927-1e37cb157bf1" />

끝맺은 시 읽기
<img width="200" alt="스크린샷 2025-06-11 오후 7 58 13" src="https://github.com/user-attachments/assets/cdc7760b-20dc-4098-8863-78ae262d608d" />
