### PR TITLE
🐛 [fix] 작성중인 시 네비게이팅 변경 취소

### DIFF
--- a/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Collection/OngoingCollection/OngoingCollectionViewModel.swift
@@ -28,7 +28,7 @@ final class OngoingCollectionViewModel: ViewModelable {
         case backButtonTapAction
         /// 검색하기
         case search
-        /// 시 버튼 눌렀을 때 쓰는중인 시 화면(편집)으로 넘어가기
+        /// 시 버튼 눌렀을 때 쓰는중인 시 화면으로 넘어가기
         case ongoingPoemTapped(Poem)
 
     }
@@ -52,7 +52,7 @@ final class OngoingCollectionViewModel: ViewModelable {
             state.searchedPoems = searchPoems(searchText: state.searchText)
 
         case .ongoingPoemTapped(let poem):
-            coordinator.push(.poemWriting(poem))
+            coordinator.push(.poemReading(poem))
         }
     }
 

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemReading/PoemReadingViewModel.swift
@@ -92,7 +92,7 @@ final class PoemReadingViewModel: ViewModelable {
         case .success:
             print("삭제 성공")
             // 끝맺은 시 뷰로 이동
-            coordinator.removeAll()
+            coordinator.popLast()
         
         case .failure(let error):
             print("시 삭제 실패: ",error.localizedDescription)

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingView.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingView.swift
@@ -70,7 +70,7 @@ struct PoemWritingView: View {
                         isShowingAlert = false
                     },
                     onSecondary: {
-                        viewModel.action(.deletePoem(context: context))
+                        viewModel.action(.backButtonTapped)
                     },
                     isVisible: $isShowingAlert
                 )

--- a/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingViewModel.swift
+++ b/FunForYou/FunForYou/Sources/Presentation/Poem/PoemWriting/PoemWritingViewModel.swift
@@ -49,7 +49,7 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
         case onAppeared(context: ModelContext)
         case updateCanSave
         case saveOrUpdatePoem(context: ModelContext, isCompleted: Bool)
-        case deletePoem(context: ModelContext)
+        case backButtonTapped
     }
 
     func action(_ action: Action) {
@@ -104,8 +104,8 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
         case .updateCanSave:
             canSave = Self.updateCanSave(poem: state.poem)
             
-        case .deletePoem(let context):
-            deletePoemById(context: context)
+        case .backButtonTapped:
+            coordinator.popLast()
         }
 
     }
@@ -185,19 +185,6 @@ final class PoemWritingViewModel: ViewModelable, ObservableObject {
 
         case .none:
             break
-        }
-    }
-
-    private func deletePoemById(context: ModelContext) {
-        let result = SwiftDataManager.shared.deletePoem(poem: state.poem, context: context)
-        
-        switch result {
-        case .success:
-            print("삭제 성공")
-            coordinator.popLast()
-        
-        case .failure(let error):
-            print("시 삭제 실패: ",error.localizedDescription)
         }
     }
     


### PR DESCRIPTION
### 🖥️ 작업 내역

close #121

> 구현 내용 및 작업 했던 내역을 적어주세요.
이전에 PR 중에서 작성중인 시 클릭시 바로 편집 뷰로 이동되도록 개선했던 작업 취소했습니다.
바로 편집 뷰로 이동하게 되면, 삭제 버튼을 선택할 수 있는 경우가 사라지게 됩니다.
이를 해결하기 위해서 뒤로가기 버튼 클릭시 삭제를 선택할 수 있도록 했습니다.
하지만, 사용자 플로우를 헤치는 경우라고 생각해, 다시 원 상태로 복구시켰습니다.!

수정 시점에, 시를 삭제하면 모두 removeAll()을 통해서 끝맺은 시로 돌아가고 있는 상황을 함께 수정했습니다.
작성중인 시를 삭제하면 작성중인 시 페이지로, 완성된 시를 삭제하면 끝맺은 시 페이지로 전환되도록 popLast() 적용으로 수정했습니다.