### PR TITLE
✨ [feat] 네비게이션 뒤로가기 제스쳐를 위한 Extension 추가

### DIFF
--- a/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
+++ b/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
@@ -1,0 +1,21 @@
+//
+//  Navigation+Ext.swift
+//  FunForYou
+//
+//  Created by 배현진 on 6/12/25.
+//
+
+import UIKit
+
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+        // TODO: - 필요 시점에 뷰 스택 2개 이상인 경우에만 사용 가능하도록 설정 (Berry)
+        // 현재는 네비게이션 구조가 잘 적용되어 있고, 예외의 경우가 없어서 뷰 스택이 1개인 경우 뒤로가기 발생하지 않는다.
+    }
+}

--- a/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
+++ b/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
@@ -15,7 +15,5 @@ extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
 
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return viewControllers.count > 1
-        // TODO: - 필요 시점에 뷰 스택 2개 이상인 경우에만 사용 가능하도록 설정 (Berry)
-        // 현재는 네비게이션 구조가 잘 적용되어 있고, 예외의 경우가 없어서 뷰 스택이 1개인 경우에도 문제없이 뒤로가기 수행된다.
     }
 }

--- a/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
+++ b/FunForYou/FunForYou/Sources/Common/Extension/Navigation+Ext.swift
@@ -16,6 +16,6 @@ extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return viewControllers.count > 1
         // TODO: - 필요 시점에 뷰 스택 2개 이상인 경우에만 사용 가능하도록 설정 (Berry)
-        // 현재는 네비게이션 구조가 잘 적용되어 있고, 예외의 경우가 없어서 뷰 스택이 1개인 경우 뒤로가기 발생하지 않는다.
+        // 현재는 네비게이션 구조가 잘 적용되어 있고, 예외의 경우가 없어서 뷰 스택이 1개인 경우에도 문제없이 뒤로가기 수행된다.
     }
 }


### PR DESCRIPTION
### 🖥️ 작업 내역

close #120 

> 구현 내용 및 작업 했던 내역을 적어주세요.

UINavigationController Extension을 추가해 뒤로가기 제스쳐를 적용했습니다.

https://github.com/user-attachments/assets/64c32e89-f652-4874-a712-5c0c1282bd52

이제 자연스럽게 제스쳐를 통해 뒤로가기를 수행할 수 있습니다.

현재 저희 구현 내용에서는 네비게이션 구조가 잘 적용되어 있고, 예외의 경우가 없어서 뷰 스택이 1개인 경우에도 문제없이 뒤로가기 수행됩니다.
이후 구현에서 뷰 스택이 2개인 경우부터만 뒤로가기 제스쳐를 적용하기 위해서는 추가 구현이 필요합니다.
